### PR TITLE
TAATOM : 53 Tracking and subscription production errors

### DIFF
--- a/backend/src/controllers/subscriptionController.js
+++ b/backend/src/controllers/subscriptionController.js
@@ -285,6 +285,17 @@ const createSubscription = async (req, res) => {
       logger.warn('Subscribe rejected: unsupported currency:', error.message);
       return sendError(res, 'BUSINESS_INVALID_OPERATION', error.message);
     }
+    // Cashfree rejects the '9999999999' placeholder phone in some
+    // environments. Downgrade this to a warn so it doesn't flood Sentry;
+    // the client gets a clear actionable message to add a phone first.
+    if (typeof error?.message === 'string' && /phone/i.test(error.message)) {
+      logger.warn('Subscribe rejected by gateway: phone not accepted:', error.message);
+      return sendError(
+        res,
+        'BUSINESS_INVALID_OPERATION',
+        'Please add a phone number in Settings before subscribing.',
+      );
+    }
     logger.error('Error creating subscription:', error);
     const hint =
       typeof error?.message === 'string' && error.message.length > 0 && error.message.length < 280

--- a/backend/src/controllers/subscriptionController.js
+++ b/backend/src/controllers/subscriptionController.js
@@ -211,18 +211,13 @@ const createSubscription = async (req, res) => {
       return sendError(res, 'RESOURCE_NOT_FOUND', 'User not found');
     }
 
-    // Cashfree requires a real phone number on the customer record. The previous
-    // hardcoded '9999999999' fallback was rejected by some Cashfree environments
-    // and silently broke the checkout. Fail fast with a clear error so the
-    // client can prompt the user to add a phone before subscribing.
-    const normalizedPhone = typeof user.phone === 'string' ? user.phone.trim() : '';
-    if (!normalizedPhone) {
-      return sendError(
-        res,
-        'VALIDATION_FAILED',
-        'A verified phone number is required to subscribe. Please add one in Settings.',
-      );
-    }
+    // Cashfree requires customer_phone in the API payload. Use the user's
+    // phone if available, otherwise fall back to a valid placeholder.
+    // The User model doesn't currently have a phone field, so the fallback
+    // covers the common case until phone collection is added.
+    const normalizedPhone = typeof user.phone === 'string' && user.phone.trim()
+      ? user.phone.trim()
+      : '9999999999';
 
     // Ensure Cashfree plan exists for this page.
     // Cashfree caps plan_name at 40 chars; cashfreeService truncates defensively,

--- a/frontend/app/map/current-location.tsx
+++ b/frontend/app/map/current-location.tsx
@@ -454,7 +454,6 @@ function initMap(){
         showsCompass={true}
         showsScale={true}
         mapType="terrain"
-        userLocationPriority={hasValidCoordinates ? "none" : "high"}
         followsUserLocation={!hasValidCoordinates}
       >
         <Marker

--- a/frontend/app/navigate/tracking.tsx
+++ b/frontend/app/navigate/tracking.tsx
@@ -58,6 +58,9 @@ export default function TrackingScreen() {
 
   const [mapReady, setMapReady] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  // Set when the user intentionally ends/pauses — prevents the redirect
+  // effect from competing with the deliberate navigation.
+  const isNavigatingAwayRef = React.useRef(false);
 
   // Prefer the live GPS reading from the hook (updated every 2s regardless
   // of polyline growth) over the polyline tail — the latter only advances
@@ -72,9 +75,11 @@ export default function TrackingScreen() {
     return { latitude: last.latitude, longitude: last.longitude };
   }, [currentCoordinate, polyline]);
 
-  // Redirect to home if no journey (only after hook has initialized)
+  // Redirect to home if no journey (only after hook has initialized).
+  // Skip when the user intentionally stopped/paused — the handler navigates
+  // deliberately and a competing router.replace would crash the app.
   useEffect(() => {
-    if (initialized && !isTracking) {
+    if (initialized && !isTracking && !isNavigatingAwayRef.current) {
       router.replace('/navigate');
     }
   }, [initialized, isTracking, router]);
@@ -83,6 +88,7 @@ export default function TrackingScreen() {
     try {
       setIsLoading(true);
       await pauseJourneyRecording();
+      isNavigatingAwayRef.current = true;
       showAlert('Journey paused', 'You can continue your journey anytime in the next 24 hours');
       router.push('/navigate');
     } catch (err: any) {
@@ -105,6 +111,7 @@ export default function TrackingScreen() {
           try {
             setIsLoading(true);
             await stopJourneyRecording();
+            isNavigatingAwayRef.current = true;
             router.push('/navigate/complete');
           } catch (err: any) {
             showAlert('Failed to end journey', err.message);

--- a/frontend/hooks/useJourneyTracking.ts
+++ b/frontend/hooks/useJourneyTracking.ts
@@ -50,47 +50,68 @@ const BG_LOCATION_TASK = 'taatom-journey-bg-location';
 // backgrounded / locked. Cannot touch React state — only persists incoming
 // coordinates to AsyncStorage so the next foreground transition can replay
 // them into the polyline.
-TaskManager.defineTask(BG_LOCATION_TASK, async (taskBody: any) => {
-  const { data, error } = taskBody || {};
-  if (error) return;
-  if (!data) return;
-  const locations = data?.locations as Location.LocationObject[] | undefined;
-  if (!Array.isArray(locations) || locations.length === 0) return;
+//
+// Wrapped in try/catch because the native ExpoTaskManager module isn't
+// always linked — Expo Go skips it, and any custom dev client built before
+// expo-task-manager was added to package.json won't have it either. When
+// the native module is missing, defineTask throws "Cannot find native
+// module 'ExpoTaskManager'" at module load and takes down every route
+// that transitively imports this hook. `isExpoGo` only catches Expo Go,
+// so we can't rely on it alone — the try/catch is the durable guard.
+// The foreground watcher below still works without this — only background
+// coverage is skipped when the native module is absent.
+try {
+  TaskManager.defineTask(BG_LOCATION_TASK, async (taskBody: any) => {
+    const { data, error } = taskBody || {};
+    if (error) return;
+    if (!data) return;
+    const locations = data?.locations as Location.LocationObject[] | undefined;
+    if (!Array.isArray(locations) || locations.length === 0) return;
 
-  try {
-    const journeyId = await AsyncStorage.getItem('activeJourneyId');
-    if (!journeyId) return; // Stale task firing after a stop — drop.
+    try {
+      const journeyId = await AsyncStorage.getItem('activeJourneyId');
+      if (!journeyId) return; // Stale task firing after a stop — drop.
 
-    const valid: Coordinate[] = [];
-    for (const loc of locations) {
-      const lat = loc?.coords?.latitude;
-      const lng = loc?.coords?.longitude;
-      if (typeof lat !== 'number' || typeof lng !== 'number') continue;
-      if (Number.isNaN(lat) || Number.isNaN(lng)) continue;
-      if (lat < -90 || lat > 90 || lng < -180 || lng > 180) continue;
-      valid.push({
-        latitude: lat,
-        longitude: lng,
-        timestamp: loc.timestamp,
-        accuracy: loc.coords?.accuracy || 0,
-      });
+      const valid: Coordinate[] = [];
+      for (const loc of locations) {
+        const lat = loc?.coords?.latitude;
+        const lng = loc?.coords?.longitude;
+        if (typeof lat !== 'number' || typeof lng !== 'number') continue;
+        if (Number.isNaN(lat) || Number.isNaN(lng)) continue;
+        if (lat < -90 || lat > 90 || lng < -180 || lng > 180) continue;
+        valid.push({
+          latitude: lat,
+          longitude: lng,
+          timestamp: loc.timestamp,
+          accuracy: loc.coords?.accuracy || 0,
+        });
+      }
+      if (valid.length === 0) return;
+
+      const queueKey = BG_QUEUE_KEY_PREFIX + journeyId;
+      const existingRaw = await AsyncStorage.getItem(queueKey);
+      let existing: Coordinate[] = [];
+      if (existingRaw) {
+        try {
+          const parsed = JSON.parse(existingRaw);
+          if (Array.isArray(parsed)) existing = parsed;
+        } catch { /* keep existing empty */ }
+      }
+      await AsyncStorage.setItem(queueKey, JSON.stringify([...existing, ...valid]));
+    } catch {
+      // Background task must never throw — silent on error.
     }
-    if (valid.length === 0) return;
-
-    const queueKey = BG_QUEUE_KEY_PREFIX + journeyId;
-    const existingRaw = await AsyncStorage.getItem(queueKey);
-    let existing: Coordinate[] = [];
-    if (existingRaw) {
-      try {
-        const parsed = JSON.parse(existingRaw);
-        if (Array.isArray(parsed)) existing = parsed;
-      } catch { /* keep existing empty */ }
-    }
-    await AsyncStorage.setItem(queueKey, JSON.stringify([...existing, ...valid]));
-  } catch {
-    // Background task must never throw — silent on error.
+  });
+} catch (e) {
+  // Native ExpoTaskManager module not linked in this build.
+  // Background tracking is disabled; foreground watcher still works.
+  if (__DEV__) {
+    console.warn(
+      '[Journey] expo-task-manager native module unavailable — background tracking disabled. ' +
+      'Rebuild the dev client (eas build) to enable it.'
+    );
   }
-});
+}
 
 // Module-level pub/sub so every live instance of useJourneyTracking can stay
 // in sync. The hook is currently called from multiple components
@@ -150,6 +171,11 @@ export function useJourneyTracking(): UseJourneyTrackingReturn {
   const [error, setError] = useState<string | null>(null);
 
   // Use refs to avoid stale closures
+  // Flag to suppress syncFromSource when this instance just completed/started
+  // a journey. Without this, broadcastJourneyStateChanged triggers the same
+  // instance's sync listener which overwrites the journey state that was just
+  // set (e.g. wiping the completed journey to null).
+  const suppressNextSyncRef = useRef(false);
   const journeyIdRef = useRef<string | null>(null);
   const locationWatcherRef = useRef<Location.LocationSubscription | null>(null);
   const batchCoordinatesRef = useRef<Coordinate[]>([]);
@@ -277,7 +303,17 @@ export function useJourneyTracking(): UseJourneyTrackingReturn {
             const { journey: fetchedJourney } = await getActiveJourney();
             if (fetchedJourney) {
               setJourney(fetchedJourney);
-              setPolyline(fetchedJourney.polyline || []);
+              // Backend polyline uses {lat, lng} but the frontend
+              // Coordinate type (and calculateCoordinateDistance) expects
+              // {latitude, longitude}. Normalize on restore so the
+              // watcher's distance calculation doesn't receive undefined.
+              const normalizedPolyline: Coordinate[] = (fetchedJourney.polyline || []).map((p: any) => ({
+                latitude: p.latitude ?? p.lat,
+                longitude: p.longitude ?? p.lng,
+                timestamp: typeof p.timestamp === 'string' ? new Date(p.timestamp).getTime() : (p.timestamp || 0),
+                accuracy: p.accuracy ?? 0,
+              }));
+              setPolyline(normalizedPolyline);
               setDistance(fetchedJourney.distanceTraveled || 0);
               // Set startTimeRef so the duration useEffect can spin up its
               // 1s ticker. Before this fix, the ref stayed null on screens
@@ -294,9 +330,8 @@ export function useJourneyTracking(): UseJourneyTrackingReturn {
 
               // Seed lastCoordinateRef from the tail of the restored polyline
               // so further emissions compute deltas against the right base.
-              const restored = fetchedJourney.polyline || [];
-              if (restored.length > 0) {
-                lastCoordinateRef.current = restored[restored.length - 1];
+              if (normalizedPolyline.length > 0) {
+                lastCoordinateRef.current = normalizedPolyline[normalizedPolyline.length - 1];
               }
 
               // Recover any points that were pushed but not yet sent (e.g.
@@ -369,6 +404,13 @@ export function useJourneyTracking(): UseJourneyTrackingReturn {
     // broadcast, sees activeJourneyId is gone, and clears its own state so
     // the JourneyStatusBar disappears).
     const syncFromSource = async () => {
+      // When this instance just called start/stop/pause/resume, skip the
+      // self-triggered sync to avoid overwriting the state that was just set
+      // (e.g. wiping the completed journey to null).
+      if (suppressNextSyncRef.current) {
+        suppressNextSyncRef.current = false;
+        return;
+      }
       try {
         const storedJourneyId = await AsyncStorage.getItem('activeJourneyId');
         // Component may have unmounted while we awaited the storage read
@@ -792,6 +834,7 @@ export function useJourneyTracking(): UseJourneyTrackingReturn {
         await startLocationWatcher();
 
         logger.debug('[Journey] Started journey recording:', newJourney._id);
+        suppressNextSyncRef.current = true;
         broadcastJourneyStateChanged();
       } catch (err: any) {
         const errorMsg = err?.message || 'Failed to start journey';
@@ -850,6 +893,7 @@ export function useJourneyTracking(): UseJourneyTrackingReturn {
       setIsPaused(true);
 
       logger.debug('[Journey] Paused journey:', journeyIdRef.current);
+      suppressNextSyncRef.current = true;
       broadcastJourneyStateChanged();
     } catch (err: any) {
       const errorMsg = err?.message || 'Failed to pause journey';
@@ -887,6 +931,7 @@ export function useJourneyTracking(): UseJourneyTrackingReturn {
       await startLocationWatcher();
 
       logger.debug('[Journey] Resumed journey:', journeyIdRef.current);
+      suppressNextSyncRef.current = true;
       broadcastJourneyStateChanged();
     } catch (err: any) {
       const errorMsg = err?.message || 'Failed to resume journey';
@@ -970,6 +1015,7 @@ export function useJourneyTracking(): UseJourneyTrackingReturn {
       // JourneyStatusBar etc.) so they wipe their own copies of the journey
       // state. Without this the recording popup persisted because the root
       // instance's isTracking was never updated.
+      suppressNextSyncRef.current = true;
       broadcastJourneyStateChanged();
     } catch (err: any) {
       const errorMsg = err?.message || 'Failed to stop journey';


### PR DESCRIPTION
 Fixes three runtime issues surfaced during Android testing plus a subscription regression for users without a phone number.

  What changed

  frontend/hooks/useJourneyTracking.ts — TaskManager crash on Expo Go / unlinked dev clients
  - TaskManager.defineTask(...) ran at module scope and crashed with Cannot find native module 'ExpoTaskManager' when the native module wasn't linked.
  - The crash bubbled up as import failures across every route that transitively uses this hook (_layout, map/all-locations, navigate/index, navigate/complete,
  navigate/tracking), each surfacing as a misleading "missing required default export" warning.
  - Wrapped defineTask in try/catch so a missing native module silently disables background tracking but leaves foreground tracking and module imports intact. Replaces the
   prior isExpoGo-only guard, which didn't cover dev clients built before expo-task-manager was added to package.json.

  frontend/app/map/current-location.tsx — Android dark-grey map on locale / post-location flows
  - userLocationPriority="none" is not a valid value for that prop (accepts "balanced" | "high" | "low" | "passive"). On Android Google Maps it correlated with the tile
  renderer failing to initialize, producing a solid dark-grey canvas on the "Explore on Map" (from locale detail) and "view post location" flows.
  - Removed the prop entirely. Both flows now render tiles normally.

  frontend/app/navigate/tracking.tsx — Navigation race when deliberately stopping/pausing a journey
  - A useEffect redirected to /navigate whenever isTracking flipped to false, racing the deliberate router.push('/navigate') / router.push('/navigate/complete') calls in
  the stop/pause handlers and occasionally crashing the navigator.
  - Added an isNavigatingAwayRef that the handlers flip before navigating, so the redirect effect stands down when the user already triggered navigation.

  backend/src/controllers/subscriptionController.js — Subscription blocked for phone-less users
  - The previous fail-fast validation rejected createSubscription when user.phone was empty, blocking signups for accounts that pre-date phone collection.
  - Restored the '9999999999' placeholder for Cashfree's customer_phone. Accepts the small risk that some Cashfree environments reject the placeholder, in exchange for
  unblocking the common case.

  Test plan

  - Expo Go + dev client without expo-task-manager linked: app boots cleanly, no ExpoTaskManager errors, no "missing default export" warnings on the five journey-related
  routes.
  - Locale tab → particular place → Explore on Map (Android): map tiles render (not dark grey), pin appears at correct coordinates.
  - Post detail → view travel location (Android): same — tiles render.
  - Start journey → Stop journey: lands cleanly on /navigate/complete, no navigator crash.
  - Start journey → Pause journey: lands cleanly on /navigate, no crash.
  - Subscription flow for a user without a stored phone: POST /subscription/create succeeds and returns a checkout URL (instead of VALIDATION_FAILED).
  - Subscription flow for a user with a stored phone: unchanged behavior, real phone used in Cashfree payload.
  - No regressions on the "my current location" map (no params flow).