### PR TITLE
TAATOM: Limit Metro workers to prevent worker heap OOM on Windows

### DIFF
--- a/frontend/metro.config.js
+++ b/frontend/metro.config.js
@@ -4,6 +4,9 @@ const {
 
 const config = getSentryExpoConfig(__dirname);
 
+// Limit workers to prevent memory exhaustion / OOM errors on Windows
+config.maxWorkers = 2;
+
 // Production optimizations
 const isProduction = process.env.NODE_ENV === 'production';
 


### PR DESCRIPTION
By default, Metro spawns child compilation workers equal to the number of CPU cores in your machine. On modern multi-core processors, spawning 8, 12, or 16 Node.js processes simultaneously to bundle a large project causes memory consumption to skyrocket on Windows, exceeding the default Node.js memory ceiling and resulting in:

FATAL ERROR: Zone Allocation failed - process out of memory
FATAL ERROR: Committing semi space failed. Allocation failed - JavaScript heap out of memory
Error: spawn UNKNOWN (when a worker fails to spawn due to system resources)
How We Fixed It
Limited Metro Workers: I modified 
metro.config.js
 to configure config.maxWorkers = 2. This limits the bundler to run with a maximum of 2 parallel worker processes. It keeps the build speed fast while drastically reducing the memory footprint, preventing OOM crashes during bundling.