### PR TITLE
TAATOM: Fix map preview card navigation for shorts and set circular thumbnails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ CHANGES_LOGGED.txt
 # Do NOT ignore frontend/app.json — EAS must receive it (use skip-worktree locally instead; see comment above)
 migrate_theme.js
 ag_knowledge_graph.md
+MAP_MATCHING_GUIDE.md

--- a/backend/src/__tests__/mapMatcher.test.js
+++ b/backend/src/__tests__/mapMatcher.test.js
@@ -1,0 +1,118 @@
+const { projectPointToSegment, calculateHaversine } = require('../utils/projection');
+const { matchTrajectory } = require('../utils/mapMatcher');
+const Road = require('../models/Road');
+
+describe('Map Matching Orthogonal Projection', () => {
+  test('projectPointToSegment: snaps to start point when projection factor t <= 0', () => {
+    const P = { lat: 12.96, lng: 77.59 };
+    const A = { lat: 12.97, lng: 77.59 };
+    const B = { lat: 12.98, lng: 77.59 };
+
+    const projection = projectPointToSegment(P.lat, P.lng, A.lat, A.lng, B.lat, B.lng);
+    
+    expect(projection.lat).toBeCloseTo(A.lat, 5);
+    expect(projection.lng).toBeCloseTo(A.lng, 5);
+    expect(projection.t).toBe(0);
+  });
+
+  test('projectPointToSegment: snaps to end point when projection factor t >= 1', () => {
+    const P = { lat: 12.99, lng: 77.59 };
+    const A = { lat: 12.97, lng: 77.59 };
+    const B = { lat: 12.98, lng: 77.59 };
+
+    const projection = projectPointToSegment(P.lat, P.lng, A.lat, A.lng, B.lat, B.lng);
+    
+    expect(projection.lat).toBeCloseTo(B.lat, 5);
+    expect(projection.lng).toBeCloseTo(B.lng, 5);
+    expect(projection.t).toBe(1);
+  });
+
+  test('projectPointToSegment: snaps orthogonally onto segment when 0 < t < 1', () => {
+    const A = { lat: 12.0, lng: 77.0 };
+    const B = { lat: 12.0, lng: 77.01 };
+    const P = { lat: 12.0001, lng: 77.005 };
+
+    const projection = projectPointToSegment(P.lat, P.lng, A.lat, A.lng, B.lat, B.lng);
+    
+    expect(projection.lat).toBeCloseTo(12.0, 5);
+    expect(projection.lng).toBeCloseTo(77.005, 5);
+    expect(projection.t).toBeCloseTo(0.5, 2);
+    expect(projection.distance).toBeGreaterThan(5.0);
+  });
+});
+
+describe('Map Matching HMM & Viterbi Decoder', () => {
+  let findSpy;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (findSpy) {
+      findSpy.mockRestore();
+    }
+  });
+
+  test('matchTrajectory: snaps coordinates to closest road candidates', async () => {
+    const mockRoads = [
+      {
+        _id: 'road_main_id',
+        osm_id: '111',
+        name: 'Main Street',
+        geometry: {
+          type: 'LineString',
+          coordinates: [[77.0, 12.0], [77.1, 12.0]]
+        }
+      },
+      {
+        _id: 'road_alley_id',
+        osm_id: '222',
+        name: 'Parallel Alley',
+        geometry: {
+          type: 'LineString',
+          coordinates: [[77.0, 12.0002], [77.1, 12.0002]] // ~22m away
+        }
+      }
+    ];
+
+    // Mock Road.find().limit() using jest.spyOn
+    findSpy = jest.spyOn(Road, 'find').mockImplementation(() => {
+      return {
+        limit: jest.fn().mockResolvedValue(mockRoads)
+      };
+    });
+
+    const rawPoints = [
+      { lat: 12.00001, lng: 77.001, timestamp: new Date() },
+      { lat: 12.00002, lng: 77.005, timestamp: new Date() },
+      { lat: 12.00001, lng: 77.009, timestamp: new Date() }
+    ];
+
+    const matched = await matchTrajectory(rawPoints);
+
+    expect(matched.length).toBe(3);
+    // Should snap to Main Street
+    expect(matched[0].lat).toBeCloseTo(12.0, 5);
+    expect(matched[0].lng).toBeCloseTo(77.001, 5);
+    expect(matched[1].lat).toBeCloseTo(12.0, 5);
+    expect(matched[1].lng).toBeCloseTo(77.005, 5);
+  });
+
+  test('matchTrajectory: falls back to raw coordinates when no candidates are found', async () => {
+    findSpy = jest.spyOn(Road, 'find').mockImplementation(() => {
+      return {
+        limit: jest.fn().mockResolvedValue([])
+      };
+    });
+
+    const rawPoints = [
+      { lat: 15.0, lng: 80.0, timestamp: new Date() }
+    ];
+
+    const matched = await matchTrajectory(rawPoints);
+    expect(matched.length).toBe(1);
+    expect(matched[0].lat).toBe(15.0);
+    expect(matched[0].lng).toBe(80.0);
+  });
+});

--- a/backend/src/__tests__/settingsController.test.js
+++ b/backend/src/__tests__/settingsController.test.js
@@ -1,0 +1,211 @@
+// Mock User and Activity models before requiring them
+jest.mock('../models/User', () => {
+  return {
+    findByIdAndUpdate: jest.fn(),
+    findById: jest.fn()
+  };
+});
+jest.mock('../models/Activity', () => {
+  return {
+    updateMany: jest.fn()
+  };
+});
+jest.mock('../utils/logger', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn()
+}));
+
+const { updateSettings, updateSettingCategory } = require('../controllers/settingsController');
+const User = require('../models/User');
+const Activity = require('../models/Activity');
+
+const mockRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe('Settings Controller Unit Tests', () => {
+  let req;
+  let res;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    res = mockRes();
+    req = {
+      user: { _id: 'mockUserId' }
+    };
+  });
+
+  describe('updateSettings', () => {
+    it('should return 400 if settings data is missing', async () => {
+      req.body = {};
+      await updateSettings(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+        success: false,
+        error: expect.objectContaining({
+          code: 'VAL_2001'
+        })
+      }));
+    });
+
+    it('should filter out invalid settings and update user successfully', async () => {
+      req.body = {
+        settings: {
+          privacy: {
+            profileVisibility: 'followers',
+            showLocation: true,
+            shareActivity: true,
+            invalidField: 'ignored'
+          },
+          notifications: {
+            pushNotifications: false,
+            emailNotifications: true,
+            quietHours: {
+              enabled: true,
+              startTime: '22:00',
+              endTime: '08:00',
+              days: ['monday']
+            }
+          },
+          account: {
+            theme: 'dark'
+          }
+        }
+      };
+
+      const mockUpdatedUser = {
+        settings: {
+          privacy: { profileVisibility: 'followers', showLocation: true, shareActivity: true },
+          notifications: { pushNotifications: false, emailNotifications: true },
+          account: { theme: 'dark' }
+        }
+      };
+
+      User.findByIdAndUpdate.mockReturnValue({
+        select: jest.fn().mockResolvedValue(mockUpdatedUser)
+      });
+      Activity.updateMany.mockResolvedValue({});
+
+      await updateSettings(req, res);
+
+      expect(User.findByIdAndUpdate).toHaveBeenCalledWith(
+        'mockUserId',
+        {
+          $set: {
+            'settings.privacy.profileVisibility': 'followers',
+            'settings.privacy.showLocation': true,
+            'settings.privacy.shareActivity': true,
+            'settings.notifications.pushNotifications': false,
+            'settings.notifications.emailNotifications': true,
+            'settings.notifications.quietHours.enabled': true,
+            'settings.notifications.quietHours.startTime': '22:00',
+            'settings.notifications.quietHours.endTime': '08:00',
+            'settings.notifications.quietHours.days': ['monday'],
+            'settings.account.theme': 'dark'
+          }
+        },
+        { new: true, runValidators: true }
+      );
+
+      expect(Activity.updateMany).toHaveBeenCalledWith(
+        { user: 'mockUserId' },
+        { isPublic: true }
+      );
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+        success: true,
+        message: 'Settings updated successfully'
+      }));
+    });
+
+    it('should return early with 200 if no valid settings are provided', async () => {
+      req.body = {
+        settings: {
+          privacy: {
+            invalidField: 'ignored'
+          }
+        }
+      };
+
+      const mockCurrentUser = {
+        settings: {
+          privacy: { profileVisibility: 'public' }
+        }
+      };
+
+      User.findById.mockReturnValue({
+        select: jest.fn().mockResolvedValue(mockCurrentUser)
+      });
+
+      await updateSettings(req, res);
+
+      expect(User.findByIdAndUpdate).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+        success: true,
+        message: 'Settings unchanged',
+        settings: mockCurrentUser.settings
+      }));
+    });
+  });
+
+  describe('updateSettingCategory', () => {
+    it('should update specific category and return success', async () => {
+      req.params = { category: 'privacy' };
+      req.body = {
+        profileVisibility: 'private',
+        showEmail: true
+      };
+
+      const mockCurrentUser = {
+        settings: {
+          privacy: {
+            profileVisibility: 'public',
+            showEmail: false
+          }
+        }
+      };
+
+      const mockUpdatedUser = {
+        settings: {
+          privacy: {
+            profileVisibility: 'private',
+            showEmail: true
+          }
+        }
+      };
+
+      User.findById.mockReturnValue({
+        select: jest.fn().mockResolvedValue(mockCurrentUser)
+      });
+      User.findByIdAndUpdate.mockReturnValue({
+        select: jest.fn().mockResolvedValue(mockUpdatedUser)
+      });
+
+      await updateSettingCategory(req, res);
+
+      expect(User.findByIdAndUpdate).toHaveBeenCalledWith(
+        'mockUserId',
+        {
+          $set: {
+            'settings.privacy.profileVisibility': 'private',
+            'settings.privacy.showEmail': true
+          }
+        },
+        { new: true, runValidators: true }
+      );
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+        success: true,
+        settings: mockUpdatedUser.settings
+      }));
+    });
+  });
+});

--- a/backend/src/controllers/journeyController.js
+++ b/backend/src/controllers/journeyController.js
@@ -5,6 +5,7 @@ const Journey = require('../models/Journey');
 const Post = require('../models/Post');
 const User = require('../models/User');
 const { MAX_REALISTIC_SPEED_KMH } = require('../config/tripScoreConfig');
+const { matchTrajectory } = require('../utils/mapMatcher');
 
 // ─── Road Snap ──────────────────────────────────────────────────────
 // Uses internal OSRM Match API to snap raw GPS points to the nearest road.
@@ -18,49 +19,24 @@ const { MAX_REALISTIC_SPEED_KMH } = require('../config/tripScoreConfig');
 const snapToRoads = async (polyline) => {
   if (polyline.length < 2) return polyline;
 
-  const osrmServer = process.env.OSRM_SERVER_URL || 'http://localhost:5000';
-  const coordinates = polyline.map(p => `${p.lng},${p.lat}`).join(';');
-  const radiuses = polyline.map(p => p.accuracy || 20).join(';');
-  const timestamps = polyline.map(p => Math.floor(new Date(p.timestamp).getTime() / 1000)).join(';');
-
-  const osrmUrl = `${osrmServer}/match/v1/driving/${coordinates}?radiuses=${radiuses}&timestamps=${timestamps}&geometries=geojson&overview=full`;
-
   try {
-    const response = await fetch(osrmUrl);
-    if (!response.ok) {
-      logger.warn(`OSRM Match returned status ${response.status} — falling back to raw polyline`);
-      return polyline;
-    }
+    const formattedPoints = polyline.map(p => ({
+      lat: p.lat ?? p.latitude,
+      lng: p.lng ?? p.longitude,
+      timestamp: p.timestamp ? new Date(p.timestamp) : new Date(),
+      segmentBreak: p.segmentBreak || false
+    }));
 
-    const data = await response.json();
-    if (data.code === 'Ok' && data.matchings && data.matchings.length > 0) {
-      const bestMatch = data.matchings[0];
-      const originalLength = polyline.length;
-      const matchedCoords = bestMatch.geometry.coordinates;
-
-      return matchedCoords.map((coord, idx) => {
-        let origIdx = 0;
-        if (matchedCoords.length > 1) {
-          origIdx = Math.min(
-            Math.floor((idx / (matchedCoords.length - 1)) * (originalLength - 1)),
-            originalLength - 1
-          );
-        }
-        const originalPoint = polyline[origIdx];
-        return {
-          lat: coord[1],
-          lng: coord[0],
-          timestamp: originalPoint.timestamp ? new Date(originalPoint.timestamp) : new Date(),
-          accuracy: originalPoint.accuracy || 0,
-          segmentBreak: originalPoint.segmentBreak || false
-        };
-      });
-    } else {
-      logger.warn(`OSRM Match returned code: ${data.code} — falling back to raw polyline`);
-      return polyline;
-    }
+    const snapped = await matchTrajectory(formattedPoints);
+    return snapped.map(p => ({
+      lat: p.lat,
+      lng: p.lng,
+      timestamp: p.timestamp,
+      accuracy: 0,
+      segmentBreak: p.segmentBreak
+    }));
   } catch (err) {
-    logger.warn('OSRM snap failed (non-blocking), keeping raw polyline:', err.message);
+    logger.warn('Custom HMM road snap failed (non-blocking), keeping raw polyline:', err.message);
     return polyline;
   }
 };
@@ -406,40 +382,22 @@ const updateLocation = async (req, res) => {
       });
     }
 
-    // Call OSRM Match API to snap coordinates to road network
+    // Call custom map matcher to snap coordinates to road network
     let snappedPoints = [];
     let matchSucceeded = false;
 
-    const osrmServer = process.env.OSRM_SERVER_URL || 'http://localhost:5000';
-
     if (filteredCoords.length >= 2) {
-      const coordinatesParam = filteredCoords.map(p => `${p.lng},${p.lat}`).join(';');
-      const radiusesParam = filteredCoords.map(p => p.accuracy || 20).join(';');
-      const timestampsParam = filteredCoords.map(p => Math.floor(new Date(p.timestamp).getTime() / 1000)).join(';');
-
-      const osrmUrl = `${osrmServer}/match/v1/driving/${coordinatesParam}?radiuses=${radiusesParam}&timestamps=${timestampsParam}&geometries=geojson&overview=full`;
-
       try {
-        const response = await fetch(osrmUrl);
-        if (response.ok) {
-          const data = await response.json();
-          if (data.code === 'Ok' && data.matchings && data.matchings.length > 0) {
-            const bestMatch = data.matchings[0];
-            const matchedCoords = bestMatch.geometry.coordinates;
-
-            snappedPoints = matchedCoords.map(coord => ({
-              lat: coord[1],
-              lng: coord[0]
-            }));
-            matchSucceeded = true;
-          } else {
-            logger.warn(`OSRM Match returned code: ${data.code} — falling back to raw coords`);
-          }
-        } else {
-          logger.warn(`OSRM Match API returned status: ${response.status} — falling back to raw coords`);
+        const snapped = await matchTrajectory(filteredCoords);
+        if (snapped && snapped.length > 0) {
+          snappedPoints = snapped.map(p => ({
+            lat: p.lat,
+            lng: p.lng
+          }));
+          matchSucceeded = true;
         }
       } catch (err) {
-        logger.warn(`OSRM Match call failed — falling back to raw coords: ${err.message}`);
+        logger.warn(`Custom map matcher failed — falling back to raw coords: ${err.message}`);
       }
     }
 

--- a/backend/src/controllers/postController.js
+++ b/backend/src/controllers/postController.js
@@ -566,6 +566,7 @@ const getPostById = async (req, res) => {
               {
                 $project: {
                   fullName: 1,
+                  username: 1,
                   profilePic: 1,
                   profilePicStorageKey: 1,
                   followers: 1, // Include followers for follow status check

--- a/backend/src/controllers/postController.js
+++ b/backend/src/controllers/postController.js
@@ -7,7 +7,7 @@ const Activity = require('../models/Activity');
 const Hashtag = require('../models/Hashtag');
 const { getOptimizedImageUrl } = require('../config/cloudinary');
 const { buildMediaKey, uploadObject, deleteObject } = require('../services/storage');
-const { generateSignedUrl, generateSignedUrls, resolveProfilePic } = require('../services/mediaService');
+const { generateSignedUrl, generateSignedUrls, resolveProfilePic, resolveSong } = require('../services/mediaService');
 const { getFollowers } = require('../utils/socketBus');
 const { getIO } = require('../socket');
 const logger = require('../utils/logger');
@@ -1408,6 +1408,7 @@ const cursor = req.query.cursor || (req.query.page && isNaN(Number(req.query.pag
               { 
                 $project: { 
                   fullName: 1, 
+                  username: 1,
                   profilePic: 1,
                   profilePicStorageKey: 1,
                   followers: currentUserId ? { $cond: [{ $eq: ['$_id', currentUserId] }, '$followers', []] } : []
@@ -1424,7 +1425,7 @@ const cursor = req.query.cursor || (req.query.page && isNaN(Number(req.query.pag
           foreignField: '_id',
           as: 'commentUsers',
           pipeline: [
-            { $project: { fullName: 1, profilePic: 1, profilePicStorageKey: 1 } }
+            { $project: { fullName: 1, username: 1, profilePic: 1, profilePicStorageKey: 1 } }
           ]
         }
       },
@@ -1443,6 +1444,8 @@ const cursor = req.query.cursor || (req.query.page && isNaN(Number(req.query.pag
                 cloudinaryUrl: 1, 
                 s3Url: 1, 
                 thumbnailUrl: 1, 
+                imageUrl: 1,
+                imageStorageKey: 1,
                 storageKey: 1,
                 cloudinaryKey: 1,
                 s3Key: 1,
@@ -1520,18 +1523,7 @@ const cursor = req.query.cursor || (req.query.page && isNaN(Number(req.query.pag
 
       // Generate signed URL for song if present (same logic as getShorts)
       if (short.song?.songId) {
-        const storageKey = short.song.songId.storageKey || short.song.songId.cloudinaryKey || short.song.songId.s3Key;
-        if (storageKey) {
-          try {
-            const songUrl = await generateSignedUrl(storageKey, 'AUDIO');
-            short.song.songId.s3Url = songUrl;
-            short.song.songId.cloudinaryUrl = songUrl;
-          } catch (error) {
-            logger.warn(`Failed to generate song URL for short ${short._id}:`, error.message);
-            short.song.songId.s3Url = null;
-            short.song.songId.cloudinaryUrl = null;
-          }
-        }
+        await resolveSong(short.song.songId);
       }
 
       // Generate signed URLs for short video and thumbnail
@@ -3109,7 +3101,7 @@ const getShorts = async (req, res) => {
           foreignField: '_id',
           as: 'user',
           pipeline: [
-            { $project: { fullName: 1, profilePic: 1, profilePicStorageKey: 1, followers: 1 } }
+            { $project: { fullName: 1, username: 1, profilePic: 1, profilePicStorageKey: 1, followers: 1 } }
           ]
         }
       },
@@ -3136,7 +3128,7 @@ const getShorts = async (req, res) => {
           foreignField: '_id',
           as: 'commentUsers',
           pipeline: [
-            { $project: { fullName: 1, profilePic: 1, profilePicStorageKey: 1 } }
+            { $project: { fullName: 1, username: 1, profilePic: 1, profilePicStorageKey: 1 } }
           ]
         }
       },
@@ -3155,6 +3147,8 @@ const getShorts = async (req, res) => {
                 s3Url: 1,
                 cloudinaryUrl: 1,
                 thumbnailUrl: 1,
+                imageUrl: 1,
+                imageStorageKey: 1,
                 storageKey: 1,
                 cloudinaryKey: 1,
                 s3Key: 1,
@@ -3243,44 +3237,7 @@ const getShorts = async (req, res) => {
       
       // Generate signed URL for song if present (same logic as getPosts)
       if (short.song?.songId) {
-        console.warn('[SHORTS-SONG] Processing song for short:', {
-          shortId: String(short._id),
-          songId: String(short.song.songId._id || short.song.songId),
-          storageKey: short.song.songId.storageKey || null,
-          cloudinaryKey: short.song.songId.cloudinaryKey || null,
-          s3Key: short.song.songId.s3Key || null,
-          title: short.song.songId.title || null,
-        });
-        const storageKey = short.song.songId.storageKey || short.song.songId.cloudinaryKey || short.song.songId.s3Key;
-        if (storageKey) {
-          try {
-            const songUrl = await generateSignedUrl(storageKey, 'AUDIO');
-            short.song.songId.s3Url = songUrl;
-            short.song.songId.cloudinaryUrl = songUrl; // Backward compatibility
-            console.warn('[SHORTS-SONG] Generated song URL:', {
-              shortId: String(short._id),
-              storageKey,
-              songUrl: songUrl ? (String(songUrl).substring(0, 80) + '...') : 'NULL',
-            });
-          } catch (error) {
-            console.warn('[SHORTS-SONG] Failed to generate song URL:', {
-              shortId: String(short._id),
-              songId: String(short.song.songId._id),
-              error: error.message,
-            });
-            short.song.songId.s3Url = null;
-            short.song.songId.cloudinaryUrl = null;
-          }
-        } else {
-          // No storageKey — keep existing s3Url/cloudinaryUrl from DB (legacy songs)
-          logger.warn('Short song missing storage key, using stored URL if available:', {
-            shortId: short._id,
-            songId: short.song.songId._id,
-            hasS3Url: !!short.song.songId.s3Url,
-            hasCloudinaryUrl: !!short.song.songId.cloudinaryUrl
-          });
-          // Do NOT set to null — legacy songs store the URL directly in the Song document
-        }
+        await resolveSong(short.song.songId);
       } else {
         logger.debug('getShorts - No song data for short:', { shortId: short._id });
       }

--- a/backend/src/controllers/profileController.js
+++ b/backend/src/controllers/profileController.js
@@ -2409,7 +2409,7 @@ const getTravelMapData = async (req, res) => {
         const visitDate = visit.takenAt || visit.uploadedAt || new Date();
         const postDoc = visit.post;
         const postId = postDoc ? postDoc._id.toString() : null;
-        const contentType = visit.contentType || (postDoc ? postDoc.type : 'post');
+        const contentType = (postDoc && postDoc.type) || visit.contentType || 'post';
 
         let photo = null;
         let needsSignedUrl = null;

--- a/backend/src/controllers/settingsController.js
+++ b/backend/src/controllers/settingsController.js
@@ -39,7 +39,6 @@ const updateSettings = async (req, res) => {
     
     // Privacy settings
     if (settings.privacy) {
-      validSettings['settings.privacy'] = {};
       if (settings.privacy.profileVisibility && ['public', 'followers', 'private'].includes(settings.privacy.profileVisibility)) {
         validSettings['settings.privacy.profileVisibility'] = settings.privacy.profileVisibility;
       }
@@ -58,6 +57,9 @@ const updateSettings = async (req, res) => {
       if (typeof settings.privacy.allowFollowRequests === 'boolean') {
         validSettings['settings.privacy.allowFollowRequests'] = settings.privacy.allowFollowRequests;
       }
+      if (typeof settings.privacy.shareActivity === 'boolean') {
+        validSettings['settings.privacy.shareActivity'] = settings.privacy.shareActivity;
+      }
       if (settings.privacy.routeVisibility && ['everyone', 'approved_only', 'private'].includes(settings.privacy.routeVisibility)) {
         validSettings['settings.privacy.routeVisibility'] = settings.privacy.routeVisibility;
       }
@@ -65,7 +67,6 @@ const updateSettings = async (req, res) => {
 
     // Notification settings
     if (settings.notifications) {
-      validSettings['settings.notifications'] = {};
       if (typeof settings.notifications.pushNotifications === 'boolean') {
         validSettings['settings.notifications.pushNotifications'] = settings.notifications.pushNotifications;
       }
@@ -84,11 +85,30 @@ const updateSettings = async (req, res) => {
       if (typeof settings.notifications.messagesNotifications === 'boolean') {
         validSettings['settings.notifications.messagesNotifications'] = settings.notifications.messagesNotifications;
       }
+      if (typeof settings.notifications.followRequestNotifications === 'boolean') {
+        validSettings['settings.notifications.followRequestNotifications'] = settings.notifications.followRequestNotifications;
+      }
+      if (typeof settings.notifications.followApprovalNotifications === 'boolean') {
+        validSettings['settings.notifications.followApprovalNotifications'] = settings.notifications.followApprovalNotifications;
+      }
+      if (settings.notifications.quietHours && typeof settings.notifications.quietHours === 'object') {
+        if (typeof settings.notifications.quietHours.enabled === 'boolean') {
+          validSettings['settings.notifications.quietHours.enabled'] = settings.notifications.quietHours.enabled;
+        }
+        if (typeof settings.notifications.quietHours.startTime === 'string') {
+          validSettings['settings.notifications.quietHours.startTime'] = settings.notifications.quietHours.startTime;
+        }
+        if (typeof settings.notifications.quietHours.endTime === 'string') {
+          validSettings['settings.notifications.quietHours.endTime'] = settings.notifications.quietHours.endTime;
+        }
+        if (Array.isArray(settings.notifications.quietHours.days)) {
+          validSettings['settings.notifications.quietHours.days'] = settings.notifications.quietHours.days;
+        }
+      }
     }
 
     // Account settings
     if (settings.account) {
-      validSettings['settings.account'] = {};
       if (settings.account.language && typeof settings.account.language === 'string') {
         validSettings['settings.account.language'] = settings.account.language;
       }
@@ -107,6 +127,24 @@ const updateSettings = async (req, res) => {
       if (settings.account.fontSize && ['small', 'medium', 'large'].includes(settings.account.fontSize)) {
         validSettings['settings.account.fontSize'] = settings.account.fontSize;
       }
+    }
+
+    // If validSettings is empty, return early to prevent MongoDB $set empty object error
+    if (Object.keys(validSettings).length === 0) {
+      const currentUser = await User.findById(userId).select('settings');
+      if (!currentUser) {
+        return sendError(res, 'RES_3001', 'User does not exist');
+      }
+      return sendSuccess(res, 200, 'Settings unchanged', { settings: currentUser.settings });
+    }
+
+    // If shareActivity is being updated, also update all user's activities
+    if (settings.privacy && 'shareActivity' in settings.privacy) {
+      const shareActivity = settings.privacy.shareActivity !== false;
+      await Activity.updateMany(
+        { user: userId },
+        { isPublic: shareActivity }
+      ).catch(err => logger.error('Error updating activity privacy in updateSettings:', err));
     }
 
     const updatedUser = await User.findByIdAndUpdate(

--- a/backend/src/models/Road.js
+++ b/backend/src/models/Road.js
@@ -1,0 +1,29 @@
+const mongoose = require('mongoose');
+
+/**
+ * Road Segment Schema for Custom MapSnapping.
+ * Stores road geometries extracted from OpenStreetMap (OSM) as LineStrings.
+ * Indexes spatial geometry using 2dsphere index for $O(\log N)$ R-Tree candidate searches.
+ */
+const RoadSchema = new mongoose.Schema({
+  osm_id: { type: String, required: true, unique: true, index: true },
+  name: { type: String, default: 'Unnamed Road' },
+  highway: { type: String }, // e.g. 'residential', 'primary', 'service'
+  oneWay: { type: Boolean, default: false },
+  geometry: {
+    type: {
+      type: String,
+      enum: ['LineString'],
+      required: true
+    },
+    coordinates: {
+      type: [[Number]], // Array of [longitude, latitude] arrays
+      required: true
+    }
+  }
+});
+
+// Spatial 2dsphere index for geospatial querying
+RoadSchema.index({ geometry: '2dsphere' });
+
+module.exports = mongoose.model('Road', RoadSchema);

--- a/backend/src/services/mediaService.js
+++ b/backend/src/services/mediaService.js
@@ -223,6 +223,68 @@ const resolveProfilePic = async (user) => {
   return '';
 };
 
+/**
+ * Resolve song audio and artwork URLs to fresh, loadable URLs.
+ * Mutates the song object in-place (same style as resolveProfilePic's caller).
+ *
+ * @param {Object} song - plain song object
+ * @returns {Promise<void>}
+ */
+const resolveSong = async (song) => {
+  if (!song || typeof song !== 'object') return;
+
+  // 1. Audio URL resolution
+  const audioKey = song.storageKey || song.cloudinaryKey || song.s3Key;
+  if (audioKey) {
+    try {
+      const songUrl = await generateSignedUrl(audioKey, 'AUDIO');
+      if (songUrl) {
+        song.s3Url = songUrl;
+        song.cloudinaryUrl = songUrl; // Backward compatibility
+      }
+    } catch (error) {
+      logger.warn('resolveSong: Failed to generate audio URL:', { songId: song._id, error: error.message });
+      song.s3Url = null;
+      song.cloudinaryUrl = null;
+    }
+  }
+
+  // 2. Artwork image URL resolution
+  const imageKey = song.imageStorageKey;
+  if (imageKey) {
+    try {
+      const artworkUrl = await generateSignedUrl(imageKey, 'IMAGE');
+      if (artworkUrl) {
+        song.thumbnailUrl = artworkUrl;
+        song.imageUrl = artworkUrl;
+      }
+    } catch (err) {
+      logger.warn('resolveSong: Failed to generate artwork URL from key:', { songId: song._id, error: err.message });
+    }
+  } else {
+    // Check if either imageUrl or thumbnailUrl has a signed URL
+    const targetUrl = song.imageUrl || song.thumbnailUrl;
+    if (targetUrl && typeof targetUrl === 'string') {
+      if (isSignedUrl(targetUrl)) {
+        const key = extractStorageKeyFromUrl(targetUrl);
+        if (key) {
+          try {
+            const artworkUrl = await generateSignedUrl(key, 'IMAGE');
+            if (artworkUrl) {
+              song.thumbnailUrl = artworkUrl;
+              song.imageUrl = artworkUrl;
+            }
+          } catch (_) {}
+        }
+      } else {
+        // Fallback for permanent URLs
+        song.thumbnailUrl = targetUrl;
+        song.imageUrl = targetUrl;
+      }
+    }
+  }
+};
+
 module.exports = {
   generateSignedUrl,
   generateSignedUrls,
@@ -230,6 +292,8 @@ module.exports = {
   isSignedUrl,
   getStorageKeyFromDocument,
   resolveProfilePic,
+  resolveSong,
   EXPIRY_TIMES
 };
+
 

--- a/backend/src/services/tripVisitService.js
+++ b/backend/src/services/tripVisitService.js
@@ -522,7 +522,7 @@ const createTripVisitFromPost = async (post, metadata = {}) => {
       user: post.user,
       post: post._id,
       posts: [post._id], // Track all posts at this location
-      contentType: 'post',
+      contentType: metadata.contentType || (post.type === 'short' ? 'short' : 'post'),
       lat,
       lng,
       continent: continent === 'Unknown' ? 'Unknown' : continent.toUpperCase(),
@@ -782,6 +782,7 @@ const updateTripVisitFromPost = async (post, metadata = {}, existingVisitId = nu
     tripVisit.verificationReason = verificationReason;
     tripVisit.uploadedAt = post.createdAt;
     tripVisit.isActive = post.isActive !== false;
+    tripVisit.contentType = metadata.contentType || (post.type === 'short' ? 'short' : 'post');
     
     if (metadata.takenAt) {
       tripVisit.takenAt = metadata.takenAt;

--- a/backend/src/utils/mapMatcher.js
+++ b/backend/src/utils/mapMatcher.js
@@ -1,0 +1,193 @@
+// backend/src/utils/mapMatcher.js
+const Road = require('../models/Road');
+const { projectPointToSegment, calculateHaversine } = require('./projection');
+
+// Configuration parameters for HMM & Viterbi MapSnapping
+const SIGMA_Z = 8.0;          // GPS accuracy noise standard deviation in meters
+const BETA = 25.0;            // Transition scale parameter in meters
+const MAX_SEARCH_RADIUS = 30.0; // Max radius (meters) to query candidate road segments
+
+/**
+ * Estimates driving routing distance between two snapped candidate locations.
+ * If candidates reside on the same OSM road segment, it calculates straight-line distance.
+ * If they reside on different roads, it approximates routing distance using a Manhattan/topological scale factor.
+ * 
+ * @param {object} cPrev Previous candidate point.
+ * @param {object} cCurr Current candidate point.
+ * @returns {number} Estimated route distance in meters.
+ */
+function estimateRoutingDistance(cPrev, cCurr) {
+  const linearDist = calculateHaversine(cPrev.lat, cPrev.lng, cCurr.lat, cCurr.lng);
+  
+  if (cPrev.roadId === cCurr.roadId) {
+    return linearDist;
+  }
+  
+  // Apply Manhattan grid detour scaling factor (approximates road grid curvature)
+  return linearDist * 1.35;
+}
+
+/**
+ * Find nearby road segment candidates within a 30m radius of a location.
+ * Projects the query point onto road LineString sub-segments.
+ * 
+ * @param {number} lat Coordinate latitude.
+ * @param {number} lng Coordinate longitude.
+ * @returns {Promise<Array>} Array of candidate snapped points.
+ */
+async function findCandidates(lat, lng) {
+  try {
+    const roads = await Road.find({
+      geometry: {
+        $nearSphere: {
+          $geometry: { type: 'Point', coordinates: [lng, lat] },
+          $maxDistance: MAX_SEARCH_RADIUS
+        }
+      }
+    }).limit(6); // Query up to 6 closest roads to prevent excessive segment calculations
+
+    const candidates = [];
+    for (const road of roads) {
+      const coords = road.geometry.coordinates; // LineString coords: [[lng, lat], ...]
+      
+      // Calculate projections for all segment lines in the road geometry
+      for (let i = 0; i < coords.length - 1; i++) {
+        const aLng = coords[i][0];
+        const aLat = coords[i][1];
+        const bLng = coords[i+1][0];
+        const bLat = coords[i+1][1];
+
+        const projection = projectPointToSegment(lat, lng, aLat, aLng, bLat, bLng);
+        candidates.push({
+          lat: projection.lat,
+          lng: projection.lng,
+          distance: projection.distance,
+          roadId: road._id.toString(),
+          osmId: road.osm_id,
+          roadName: road.name || 'Unnamed Road'
+        });
+      }
+    }
+
+    // Sort candidates by perpendicular distance and select top 3
+    return candidates.sort((a, b) => a.distance - b.distance).slice(0, 3);
+  } catch (err) {
+    return [];
+  }
+}
+
+/**
+ * Match raw trajectory of coordinates to road network using HMM and Viterbi.
+ * Runs completely self-hosted without external API requests.
+ * 
+ * @param {Array} rawPoints Array of { lat, lng, timestamp, segmentBreak } locations.
+ * @returns {Promise<Array>} Snapped coordinates { lat, lng, timestamp, segmentBreak }.
+ */
+async function matchTrajectory(rawPoints) {
+  if (!Array.isArray(rawPoints) || rawPoints.length === 0) return [];
+  if (rawPoints.length === 1) {
+    const candidates = await findCandidates(rawPoints[0].lat, rawPoints[0].lng);
+    return candidates.length > 0 
+      ? [{ lat: candidates[0].lat, lng: candidates[0].lng, timestamp: rawPoints[0].timestamp }] 
+      : [rawPoints[0]];
+  }
+
+  // 1. Retrieve geospatial candidates for each point in sequence
+  const timelineCandidates = [];
+  for (const pt of rawPoints) {
+    const cands = await findCandidates(pt.lat, pt.lng);
+    
+    // If no roads are indexed within 30m, fallback to raw point as a self-candidate
+    if (cands.length === 0) {
+      cands.push({
+        lat: pt.lat,
+        lng: pt.lng,
+        distance: 0,
+        roadId: 'fallback',
+        osmId: 'fallback',
+        roadName: 'Raw Path'
+      });
+    }
+    timelineCandidates.push(cands);
+  }
+
+  const T = rawPoints.length;
+  // Initialize probability matrix and backpointers
+  const V = Array.from({ length: T }, () => ({}));
+  const backpointers = Array.from({ length: T }, () => ({}));
+
+  // 2. Base Case: Initialization (t = 0)
+  timelineCandidates[0].forEach((cand, idx) => {
+    const emission = Math.exp(-0.5 * (cand.distance / SIGMA_Z) ** 2) / (SIGMA_Z * Math.sqrt(2 * Math.PI));
+    V[0][idx] = emission;
+    backpointers[0][idx] = null;
+  });
+
+  // 3. Recurrence Phase: Run Viterbi Decoder (t = 1 to T-1)
+  for (let t = 1; t < T; t++) {
+    const prevCands = timelineCandidates[t - 1];
+    const currCands = timelineCandidates[t];
+    const dGcd = calculateHaversine(rawPoints[t-1].lat, rawPoints[t-1].lng, rawPoints[t].lat, rawPoints[t].lng);
+
+    currCands.forEach((curr, currIdx) => {
+      const emission = Math.exp(-0.5 * (curr.distance / SIGMA_Z) ** 2) / (SIGMA_Z * Math.sqrt(2 * Math.PI));
+      let maxProb = -1;
+      let bestPrevIdx = 0;
+
+      prevCands.forEach((prev, prevIdx) => {
+        const prevV = V[t - 1][prevIdx] || 0;
+        
+        // Compute Transition Probability (exponential distribution matching relative distances)
+        const dRoute = estimateRoutingDistance(prev, curr);
+        const distanceDelta = Math.abs(dGcd - dRoute);
+        const transition = Math.exp(-distanceDelta / BETA) / BETA;
+
+        const totalProb = prevV * transition * emission;
+        if (totalProb > maxProb) {
+          maxProb = totalProb;
+          bestPrevIdx = prevIdx;
+        }
+      });
+
+      V[t][currIdx] = maxProb;
+      backpointers[t][currIdx] = bestPrevIdx;
+    });
+
+    // Renormalize row scaling to prevent floating-point numerical underflow over long sequences
+    let rowSum = 0;
+    currCands.forEach((_, idx) => { rowSum += V[t][idx]; });
+    if (rowSum > 0) {
+      currCands.forEach((_, idx) => { V[t][idx] /= rowSum; });
+    }
+  }
+
+  // 4. Backtrack the highest probability path
+  let maxFinalProb = -1;
+  let bestFinalIdx = 0;
+  timelineCandidates[T - 1].forEach((_, idx) => {
+    if (V[T - 1][idx] > maxFinalProb) {
+      maxFinalProb = V[T - 1][idx];
+      bestFinalIdx = idx;
+    }
+  });
+
+  const path = [];
+  let currIdx = bestFinalIdx;
+  for (let t = T - 1; t >= 0; t--) {
+    const candidate = timelineCandidates[t][currIdx];
+    path.unshift({
+      lat: candidate.lat,
+      lng: candidate.lng,
+      timestamp: rawPoints[t].timestamp,
+      segmentBreak: rawPoints[t].segmentBreak || false
+    });
+    currIdx = backpointers[t][currIdx];
+  }
+
+  return path;
+}
+
+module.exports = {
+  matchTrajectory,
+  findCandidates
+};

--- a/backend/src/utils/projection.js
+++ b/backend/src/utils/projection.js
@@ -1,0 +1,83 @@
+/**
+ * Orthogonal Point-to-Line Vector Projection.
+ * Used to snap raw GPS coordinates orthogonally onto road segment coordinates.
+ */
+
+/**
+ * Projects a point P orthogonally onto segment AB.
+ * Scales dimensions dynamically using cosine of latitude to resolve longitude convergence.
+ * Clamps projection factor t to [0, 1] to restrict matches onto segment endpoints.
+ * 
+ * @param {number} pLat GPS point latitude.
+ * @param {number} pLng GPS point longitude.
+ * @param {number} aLat Segment start node latitude.
+ * @param {number} aLng Segment start node longitude.
+ * @param {number} bLat Segment end node latitude.
+ * @param {number} bLng Segment end node longitude.
+ * @returns {object} { lat: snappedLat, lng: snappedLng, distance: perpendicularDistanceInMetres, t: projectionFactor }
+ */
+function projectPointToSegment(pLat, pLng, aLat, aLng, bLat, bLng) {
+  const avgLat = (aLat + bLat) / 2.0;
+  const radLat = (avgLat * Math.PI) / 180.0;
+  const cosLat = Math.cos(radLat);
+
+  // 1. Convert degree coordinates to flat Cartesian meter offsets relative to point A
+  const apX = (pLng - aLng) * 111320.0 * cosLat;
+  const apY = (pLat - aLat) * 111320.0;
+
+  const abX = (bLng - aLng) * 111320.0 * cosLat;
+  const abY = (bLat - aLat) * 111320.0;
+
+  const ab2 = abX * abX + abY * abY;
+  if (ab2 === 0) {
+    return {
+      lat: aLat,
+      lng: aLng,
+      distance: calculateHaversine(pLat, pLng, aLat, aLng),
+      t: 0
+    };
+  }
+
+  // 2. Compute projection factor t and clamp to line segment boundaries
+  let t = (apX * abX + apY * abY) / ab2;
+  t = Math.max(0, Math.min(1, t));
+
+  // 3. Interpolate snapped coordinates in degrees from A and B
+  const snappedLat = aLat + t * (bLat - aLat);
+  const snappedLng = aLng + t * (bLng - aLng);
+
+  // 4. Calculate perpendicular distance in meters
+  const dx = (pLng - snappedLng) * 111320.0 * cosLat;
+  const dy = (pLat - snappedLat) * 111320.0;
+  const distance = Math.sqrt(dx * dx + dy * dy);
+
+  return {
+    lat: snappedLat,
+    lng: snappedLng,
+    distance,
+    t
+  };
+}
+
+/**
+ * Calculates straight-line great-circle distance between two points in meters using Haversine formula.
+ */
+function calculateHaversine(lat1, lon1, lat2, lon2) {
+  const R = 6371e3; // Earth radius in meters
+  const phi1 = (lat1 * Math.PI) / 180;
+  const phi2 = (lat2 * Math.PI) / 180;
+  const deltaPhi = ((lat2 - lat1) * Math.PI) / 180;
+  const deltaLambda = ((lon2 - lon1) * Math.PI) / 180;
+
+  const a =
+    Math.sin(deltaPhi / 2) * Math.sin(deltaPhi / 2) +
+    Math.cos(phi1) * Math.cos(phi2) * Math.sin(deltaLambda / 2) * Math.sin(deltaLambda / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+  return R * c;
+}
+
+module.exports = {
+  projectPointToSegment,
+  calculateHaversine
+};

--- a/frontend/app.base.json
+++ b/frontend/app.base.json
@@ -169,7 +169,7 @@
       [
         "react-native-google-mobile-ads",
         {
-          "androidAppId": "ca-app-pub-6362359854686661~6880786152",
+          "androidAppId": "ca-app-pub-6362359854606661~6880786152",
           "iosAppId": "ca-app-pub-6362359854606661~9610954911",
           "userTrackingUsageDescription": "This identifier will be used to deliver personalized ads to you.",
           "skAdNetworkItems": [

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -171,7 +171,7 @@
       [
         "react-native-google-mobile-ads",
         {
-          "androidAppId": "ca-app-pub-6362359854686661~6880786152",
+          "androidAppId": "ca-app-pub-6362359854606661~6880786152",
           "iosAppId": "ca-app-pub-6362359854606661~9610954911",
           "userTrackingUsageDescription": "This identifier will be used to deliver personalized ads to you.",
           "skAdNetworkItems": [

--- a/frontend/app/(tabs)/_layout.tsx
+++ b/frontend/app/(tabs)/_layout.tsx
@@ -122,7 +122,6 @@ export default function TabsLayout() {
         options={{
           title: 'Shorts',
           tabBarAccessibilityLabel: 'Shorts tab',
-          unmountOnBlur: true,
         } as any}
       />
       <Tabs.Screen

--- a/frontend/app/(tabs)/_layout.tsx
+++ b/frontend/app/(tabs)/_layout.tsx
@@ -15,7 +15,7 @@ const isTabPath = (p: string | null) => {
 };
 
 export default function TabsLayout() {
-  const { isDark } = useTheme();
+  const { isDark, theme } = useTheme();
   const pathname = usePathname();
   const router = useRouter();
   const previousPathnameRef = useRef<string | null>(null);
@@ -109,6 +109,7 @@ export default function TabsLayout() {
         headerShown: false,
         lazy: true,
       }}
+      {...({ sceneContainerStyle: { backgroundColor: theme.colors.background } } as any)}
     >
       <Tabs.Screen
         name="home"

--- a/frontend/app/(tabs)/locale.tsx
+++ b/frontend/app/(tabs)/locale.tsx
@@ -475,6 +475,7 @@ interface ExpoImageWithShimmerProps {
 
 const ExpoImageWithShimmer = React.memo(({ source, style, contentFit = 'cover', cachePolicy = 'memory-disk', transition = 0 }: ExpoImageWithShimmerProps) => {
   const [loading, setLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
   const shimmerAnim = useRef(new Animated.Value(0.3)).current;
 
   useEffect(() => {
@@ -505,10 +506,11 @@ const ExpoImageWithShimmer = React.memo(({ source, style, contentFit = 'cover', 
     };
   }, [loading, shimmerAnim]);
 
-  // Handle source changes - reset loading state
+  // Handle source changes - reset loading state and error state
   const sourceUri = typeof source === 'object' ? source.uri : source;
   useEffect(() => {
     setLoading(true);
+    setHasError(false);
   }, [sourceUri]);
 
   return (
@@ -526,14 +528,31 @@ const ExpoImageWithShimmer = React.memo(({ source, style, contentFit = 'cover', 
           ]}
         />
       )}
-      <ExpoImage
-        source={source}
-        style={[style, { width: '100%', height: '100%' }]}
-        contentFit={contentFit}
-        cachePolicy={cachePolicy}
-        transition={transition}
-        onLoad={() => setLoading(false)}
-      />
+      {hasError ? (
+        <LinearGradient
+          colors={['#D4EDDA', '#A8DADC']}
+          style={StyleSheet.absoluteFillObject}
+          start={{ x: 0, y: 0 }}
+          end={{ x: 1, y: 1 }}
+        >
+          <View style={styles.mapPlaceholder}>
+            <Ionicons name="location" size={40} color="#2C5530" />
+          </View>
+        </LinearGradient>
+      ) : (
+        <ExpoImage
+          source={source}
+          style={[style, { width: '100%', height: '100%' }]}
+          contentFit={contentFit}
+          cachePolicy={cachePolicy}
+          transition={transition}
+          onLoad={() => setLoading(false)}
+          onError={() => {
+            setLoading(false);
+            setHasError(true);
+          }}
+        />
+      )}
     </View>
   );
 });
@@ -1158,7 +1177,7 @@ export default function LocaleScreen() {
   const drivingDistanceCalculatedRef = useRef<Set<string>>(new Set());
   
   // Generate location snapshot key - used to gate sorting
-  // Returns null if location is not stable (missing lat/lon or countryCode)
+  // Returns null if location is not stable (missing lat/lon)
   const getLocationSnapshotKey = useCallback((): string | null => {
     if (!userLocation || !locationPermissionGranted) {
       return null;
@@ -1167,9 +1186,9 @@ export default function LocaleScreen() {
     const lat = userLocation.latitude;
     const lon = userLocation.longitude;
     
-    // Location snapshot is stable only if we have coordinates AND countryCode
-    // city and region are optional but included in key for proper re-sorting when they become available
-    if (lat != null && lon != null && !isNaN(lat) && !isNaN(lon) && userCountryCode) {
+    // Location snapshot is stable if we have coordinates
+    // city, region, and countryCode are optional but included in key for proper re-sorting when they become available
+    if (lat != null && lon != null && !isNaN(lat) && !isNaN(lon)) {
       return `${lat.toFixed(4)}-${lon.toFixed(4)}-${userCity || 'x'}-${userState || 'x'}-${userCountryCode || 'x'}`;
     }
     
@@ -1825,14 +1844,24 @@ export default function LocaleScreen() {
   // Calculate distance for a locale (with caching and geocoding support)
   // Now uses distanceKm from locale object if available, otherwise calculates it
   const getLocaleDistance = useCallback((locale: Locale & { distanceKm?: number | null }): number | null => {
-    // First check if distanceKm is already stored in locale object (from updated state)
-    if (locale.distanceKm !== undefined && locale.distanceKm !== null) {
-      return locale.distanceKm;
-    }
-
-    // Fallback: Calculate if not stored (for backwards compatibility)
     if (!userLocation) {
       return null;
+    }
+
+    // 1. Check shared distanceCache first for driving distance
+    const userLat = roundCoord(userLocation.latitude);
+    const userLon = roundCoord(userLocation.longitude);
+    const cacheKey = `${locale._id}-${userLat}-${userLon}`;
+    if (distanceCache.has(cacheKey)) {
+      const cached = distanceCache.get(cacheKey);
+      if (cached !== undefined && cached !== null) {
+        return cached;
+      }
+    }
+
+    // 2. First check if distanceKm is already stored in locale object (from updated state)
+    if (locale.distanceKm !== undefined && locale.distanceKm !== null) {
+      return locale.distanceKm;
     }
     
     // Use coordinates from locale (may be geocoded)
@@ -1843,9 +1872,6 @@ export default function LocaleScreen() {
       return null;
     }
     
-    // Use rounded coordinates for stable cache
-    const userLat = roundCoord(userLocation.latitude);
-    const userLon = roundCoord(userLocation.longitude);
     // Note: This is async but we can't make the callback async
     // So we'll calculate synchronously using straight-line as fallback
     // The main distance calculation happens in loadAdminLocales where we await
@@ -1878,8 +1904,8 @@ export default function LocaleScreen() {
     if (hasUserLocation) {
       const INFINITY = Number.POSITIVE_INFINITY;
       sorted.sort((a, b) => {
-        const dA = (a as any).distanceKm;
-        const dB = (b as any).distanceKm;
+        const dA = getLocaleDistance(a);
+        const dB = getLocaleDistance(b);
         const effA = (dA !== null && dA !== undefined && !isNaN(dA)) ? dA : INFINITY;
         const effB = (dB !== null && dB !== undefined && !isNaN(dB)) ? dB : INFINITY;
         return effA - effB;
@@ -2058,23 +2084,25 @@ export default function LocaleScreen() {
     return sorted;
   }, []);
   
-  // Legacy sorting function (kept for backward compatibility, but should not be used)
-  // CRITICAL FIX: This function should NOT be called - use sortLocalesWithSnapshot instead
   const sortLocalesByDistance = useCallback((locales: Locale[]): Locale[] => {
-    // This is a fallback that should not be used in the new flow
-    // It's kept for compatibility with existing code that may still call it
-    const snapshot = createLocationSnapshot();
-    if (snapshot) {
-      return sortLocalesWithSnapshot(locales as (Locale & { distanceKm?: number | null })[], snapshot);
+    if (userLocation) {
+      const INFINITY = Number.POSITIVE_INFINITY;
+      return [...locales].sort((a, b) => {
+        const dA = getLocaleDistance(a);
+        const dB = getLocaleDistance(b);
+        const effA = (dA !== null && dA !== undefined && !isNaN(dA)) ? dA : INFINITY;
+        const effB = (dB !== null && dB !== undefined && !isNaN(dB)) ? dB : INFINITY;
+        return effA - effB;
+      });
     }
     
-    // Fallback: sort by createdAt if no snapshot
+    // Fallback: sort by createdAt if no location
     return [...locales].sort((a, b) => {
       const dateA = new Date(a.createdAt || 0).getTime();
       const dateB = new Date(b.createdAt || 0).getTime();
       return dateB - dateA;
     });
-  }, [createLocationSnapshot, sortLocalesWithSnapshot]);
+  }, [userLocation, getLocaleDistance]);
   
   // Bookmark Stability: Load saved locales with defensive parsing
   const loadSavedLocales = useCallback(async () => {
@@ -2191,7 +2219,7 @@ export default function LocaleScreen() {
         bgRefreshCacheRef.current.set(locale._id, Date.now());
 
         getLocaleById(locale._id)
-          .then((fresh) => {
+          .then(async (fresh) => {
             if (!isMountedRef.current) return;
             if (!fresh || typeof fresh !== 'object') return;
             setSavedLocales((prev) => prev.map((existing) => {
@@ -2209,6 +2237,35 @@ export default function LocaleScreen() {
                 distanceKm: (existing as any).distanceKm,
               } as Locale;
             }));
+
+            // Persist the refreshed image URL back to AsyncStorage cache
+            try {
+              const saved = await AsyncStorage.getItem('savedLocales');
+              if (saved) {
+                const parsed = JSON.parse(saved);
+                if (Array.isArray(parsed)) {
+                  const updated = parsed.map((existing: any) => {
+                    const existingId = typeof existing._id === 'string' ? existing._id : String(existing._id || '');
+                    if (existingId !== locale._id) return existing;
+                    return {
+                      ...existing,
+                      ...fresh,
+                      imageUrl: typeof fresh.imageUrl === 'string' && fresh.imageUrl
+                        ? fresh.imageUrl
+                        : existing.imageUrl,
+                      imageUrls: Array.isArray(fresh.imageUrls) && fresh.imageUrls.length > 0
+                        ? fresh.imageUrls
+                        : existing.imageUrls,
+                      _id: existingId,
+                    };
+                  });
+                  const stripped = updated.map(({ distanceKm, ...rest }: any) => rest);
+                  await AsyncStorage.setItem('savedLocales', JSON.stringify(stripped));
+                }
+              }
+            } catch (err) {
+              logger.warn('Failed to persist background-refreshed locales to AsyncStorage', err);
+            }
           })
           .catch(() => {
             // Drop the cache so we'll retry on next load. Persisted URL
@@ -2627,6 +2684,9 @@ export default function LocaleScreen() {
 
   // Grasp user's country code on location detection to default the country filter
   useEffect(() => {
+    // Disabled defaulting the country filter to the user's country code
+    // so we fetch and sort nearby locales globally based on user location proximity.
+    /*
     if (userCountryCode && userCountryCode.trim() !== '' && !hasDefaultedCountryRef.current) {
       if (!activeLocaleFilters.countryCode) {
         logger.debug('🌍 Grasping country and setting default country filter to user country:', userCountryCode);
@@ -2655,6 +2715,7 @@ export default function LocaleScreen() {
         }, 100);
       }
     }
+    */
   }, [userCountryCode, countries, userCountry, activeLocaleFilters.countryCode]);
 
   // Listen for bookmark changes from detail page.
@@ -2865,32 +2926,8 @@ export default function LocaleScreen() {
   };
 
   const resolveLocaleDistance = useCallback((locale: Locale): number | null => {
-    // 1. Check shared distanceCache first for driving distance
-    if (userLocation) {
-      const userLat = roundCoord(userLocation.latitude);
-      const userLon = roundCoord(userLocation.longitude);
-      const cacheKey = `${locale._id}-${userLat}-${userLon}`;
-      if (distanceCache.has(cacheKey)) {
-        const cached = distanceCache.get(cacheKey);
-        if (cached !== undefined && cached !== null) {
-          return cached;
-        }
-      }
-    }
-
-    // 2. Fall back to locale.distanceKm
-    const localeWithDistance = locale as Locale & { distanceKm?: number | null };
-    if (localeWithDistance.distanceKm !== undefined && localeWithDistance.distanceKm !== null) {
-      return localeWithDistance.distanceKm;
-    }
-
-    // 3. Fall back to straight-line distance calculation
-    if (userLocation && locationPermissionGranted) {
-      return getLocaleDistance(locale);
-    }
-
-    return null;
-  }, [userLocation, locationPermissionGranted, getLocaleDistance]);
+    return getLocaleDistance(locale);
+  }, [getLocaleDistance]);
 
   const checkIsDrivingDistance = useCallback((locale: Locale): boolean => {
     if (drivingDistanceCalculatedRef.current.has(locale._id)) {
@@ -4174,17 +4211,19 @@ export default function LocaleScreen() {
         accessibilityHint="Opens locale details"
       >
         {safeImageUrl ? (
-          <ExpoImageWithShimmer
-            source={{ uri: optimizeCloudinaryUrl(safeImageUrl, { width: 300, height: 200 }) }}
-            style={styles.cardImage as ImageStyle}
-            contentFit="cover"
-            cachePolicy="memory-disk"
-            transition={200}
-          />
+          <View style={StyleSheet.absoluteFillObject}>
+            <ExpoImageWithShimmer
+              source={{ uri: optimizeCloudinaryUrl(safeImageUrl, { width: 300, height: 200 }) }}
+              style={styles.cardImage as ImageStyle}
+              contentFit="cover"
+              cachePolicy="memory-disk"
+              transition={200}
+            />
+          </View>
         ) : (
           <LinearGradient
             colors={['#D4EDDA', '#A8DADC']}
-            style={styles.cardImage}
+            style={StyleSheet.absoluteFillObject}
             start={{ x: 0, y: 0 }}
             end={{ x: 1, y: 1 }}
           >

--- a/frontend/app/(tabs)/post.tsx
+++ b/frontend/app/(tabs)/post.tsx
@@ -2902,10 +2902,10 @@ export default function PostScreen() {
     <ErrorBoundary level="route">
     <KeyboardAvoidingView
       behavior={Platform.OS === 'ios' ? 'padding' : isWeb ? undefined : 'height'}
-      style={{ flex: 1 }}
+      style={{ flex: 1, backgroundColor: theme.colors.background || '#000000' }}
       keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 20}
     >
-      <View style={{ flex: 1, backgroundColor: 'transparent' }}>
+      <View style={{ flex: 1, backgroundColor: theme.colors.background || '#000000' }}>
         <View style={StyleSheet.absoluteFillObject}>
           <CloudPostMountainBackground />
           {(selectedImages.length > 0 || selectedVideo) && (
@@ -4445,7 +4445,7 @@ export default function PostScreen() {
     </View>
     ) : (
       // Unified Instagram 1:1 Editor view
-      <View style={{ flex: 1, backgroundColor: 'transparent' }}>
+      <View style={{ flex: 1, backgroundColor: theme.colors.background || '#000000' }}>
         <PostCreateHeader onClose={() => router.push('/(tabs)/home')} onNext={() => setShowDetails(true)} showNext={selectedImages.length > 0 || !!selectedVideo} />
         
         {/* Top Half - Preview & Crop (exactly 50% of viewport) */}

--- a/frontend/app/(tabs)/shorts.tsx
+++ b/frontend/app/(tabs)/shorts.tsx
@@ -154,6 +154,8 @@ export type ShortsScreenProps = {
   scopedUserId?: string;
   initialShortId?: string;
   isSavedShorts?: boolean;
+  isMuted?: boolean;
+  onMuteToggle?: () => void;
 };
 
 const videoSourceCache = new Map<string, { uri: string; overrideFileExtensionAndroid?: string }>();
@@ -413,10 +415,11 @@ const MemoizedVideo = React.memo(
     const nextUri = next.source && typeof next.source === 'object' && 'uri' in next.source ? (next.source as any).uri : null;
 
     // Native expo-av players are fragile when parent UI state changes. Only
-    // playback, mute, or source changes are allowed to reach the native Video.
+    // playback, mute, volume, or source changes are allowed to reach the native Video.
     return (
       prev.shouldPlay === next.shouldPlay &&
       prev.isMuted === next.isMuted &&
+      prev.volume === next.volume &&
       prevUri === nextUri
     );
   }
@@ -3489,9 +3492,10 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
     // to build and compare; deliberately avoiding JSON.stringify per cell.
     const isOwn = item.user._id === currentUser?._id;
     const isVisibleNow = index === currentVisibleIndex;
+    const isMutedByUser = props.isMuted !== undefined ? props.isMuted : mutedShorts.has(item._id);
     const cacheKey =
       `${item._id}|${index}|${isVisibleNow ? 1 : 0}|` +
-      `${isCellVideoPlaying ? 1 : 0}|${mutedShorts.has(item._id) ? 1 : 0}|` +
+      `${isCellVideoPlaying ? 1 : 0}|${isMutedByUser ? 1 : 0}|` +
       `${isSaved ? 1 : 0}|${isFollowing ? 1 : 0}|` +
       `${shouldShowPauseButton ? 1 : 0}|${shouldShowLikeAnimation ? 1 : 0}|` +
       `${sourceVersions[item._id] ?? 0}|` +
@@ -3513,7 +3517,7 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
           <View
             style={[
               styles.videoContainer,
-              { bottom: videoContainerBottom }
+              { bottom: isScopedView ? 100 : 0 }
             ]}
             onTouchStart={handlersRef.current.handleTouchStart}
             onTouchMove={handlersRef.current.handleTouchMove}
@@ -3548,7 +3552,7 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
                 <ExpoImage
                   source={{ uri: item.imageUrl }}
                   style={[styles.shortVideo as ImageStyle, StyleSheet.absoluteFillObject]}
-                  contentFit="cover"
+                  contentFit="contain"
                   cachePolicy="memory-disk"
                   transition={0}
                   onError={(e: any) => logger.warn('[shorts thumbnail] load failed', {
@@ -3582,14 +3586,14 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
                   styles.shortVideo,
                   StyleSheet.absoluteFillObject,
                 ]}
-                resizeMode={ResizeMode.COVER}
+                resizeMode={ResizeMode.CONTAIN}
                 shouldPlay={index === currentVisibleIndex && isVideoPlaying && !userPausedShortIdsRef.current.has(item._id)}
                 isLooping
                 progressUpdateIntervalMillis={100}
-                isMuted={index !== currentVisibleIndex || !!(item.song?.songId?._id || item.song?.songId) || mutedShorts.has(item._id)}
+                isMuted={index !== currentVisibleIndex || !!(item.song?.songId?._id || item.song?.songId) || (props.isMuted !== undefined ? props.isMuted : mutedShorts.has(item._id))}
                 volume={(() => {
                   const hasMusic = !!(item.song?.songId?._id || item.song?.songId);
-                  const isMutedByUser = mutedShorts.has(item._id);
+                  const isMutedByUser = props.isMuted !== undefined ? props.isMuted : mutedShorts.has(item._id);
                   return (hasMusic || isMutedByUser) ? 0.0 : 1.0;
                 })()}
                 onLoadStart={() => {
@@ -3604,7 +3608,7 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
                     const video = videoRefs.current[item._id];
                     if (video) {
                       const hasMusic = !!(item.song?.songId?._id || item.song?.songId);
-                      const isMutedByUser = mutedShorts.has(item._id);
+                      const isMutedByUser = props.isMuted !== undefined ? props.isMuted : mutedShorts.has(item._id);
                       if (hasMusic || isMutedByUser) {
                         video.setIsMutedAsync(true).catch(() => {});
                         video.setVolumeAsync(0.0).catch(() => {});
@@ -3690,7 +3694,7 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
                     
                     // CRITICAL: If music exists, or if user muted this short, ensure video stays muted
                     const hasMusic = !!(item.song?.songId?._id || item.song?.songId);
-                    const isMutedByUser = mutedShorts.has(item._id);
+                    const isMutedByUser = props.isMuted !== undefined ? props.isMuted : mutedShorts.has(item._id);
                     if ((hasMusic || isMutedByUser) && index === currentVisibleIndex) {
                       const video = videoRefs.current[item._id];
                       if (video && !status.isMuted) {
@@ -4067,7 +4071,7 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
                       post={item}
                       isVisible={isScreenFocused && index === currentVisibleIndex}
                       autoPlay={isCellVideoPlaying}
-                      externalMuted={mutedShorts.has(item._id)}
+                      externalMuted={props.isMuted !== undefined ? props.isMuted : mutedShorts.has(item._id)}
                       onPlayingChange={handleSongPlayingChange}
                     />
                   </View>
@@ -4095,7 +4099,7 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
     // swipeAnimation / fadeAnimation are Animated.Value refs from useRef ---
     // their identity never changes, so they don't belong in the deps array.
     // Including them was harmless but signaled false volatility.
-  }, [currentVisibleIndex, videoStates, followStates, savedShorts, mutedShorts, currentUser, showPauseButton, showLikeAnimation, isScreenFocused, sourceVersions, containerHeight, expandedCaptions, isVideoPlaying, localVideoUris]);
+  }, [currentVisibleIndex, videoStates, followStates, savedShorts, mutedShorts, currentUser, showPauseButton, showLikeAnimation, isScreenFocused, sourceVersions, containerHeight, expandedCaptions, isVideoPlaying, localVideoUris, props.isMuted]);
 
   const keyExtractor = useCallback((item: ShortsItem) => {
     if (isAdItem(item)) return `ad-${item.adIndex}`;
@@ -4207,29 +4211,30 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
 
       {/* Premium Top Bar Overlay */}
       {(() => {
+        // If it's a scoped view, we do NOT want to render the topBar overlay at all because the parent page renders its own header!
+        if (effectiveUserId || props.isSavedShorts) {
+          return null;
+        }
+
         const currentShort = shorts[currentVisibleIndex] as PostType | undefined;
         const hasSong = !!(currentShort?.song?.songId && (currentShort.song.songId._id || typeof currentShort.song.songId === 'string'));
-        const isMuted = currentShort ? mutedShorts.has(currentShort._id) : false;
+        const isMuted = currentShort ? (props.isMuted !== undefined ? props.isMuted : mutedShorts.has(currentShort._id)) : false;
         
         return (
-          <View style={[styles.topBar, (effectiveUserId || props.isSavedShorts) && { height: 60, backgroundColor: 'transparent' }]}>
-            <View style={[styles.topBarContent, (effectiveUserId || props.isSavedShorts) && { paddingTop: 10, height: 60 }]}>
+          <View style={styles.topBar}>
+            <View style={styles.topBarContent}>
               {/* Left Back Button */}
-              {!effectiveUserId && !props.isSavedShorts ? (
-                <TouchableOpacity
-                  style={styles.topBarButton}
-                  onPress={handleBack}
-                  accessibilityLabel="Go back"
-                  accessibilityRole="button"
-                >
-                  <Ionicons name="arrow-back" size={24} color="#fff" />
-                </TouchableOpacity>
-              ) : (
-                <View style={styles.topBarButtonEmpty} />
-              )}
+              <TouchableOpacity
+                style={styles.topBarButton}
+                onPress={handleBack}
+                accessibilityLabel="Go back"
+                accessibilityRole="button"
+              >
+                <Ionicons name="arrow-back" size={24} color="#fff" />
+              </TouchableOpacity>
 
               {/* Centered Shorts Title */}
-              {!effectiveUserId && !props.isSavedShorts && <Text style={styles.topBarTitle}>Shorts</Text>}
+              <Text style={styles.topBarTitle}>Shorts</Text>
 
               {/* Right Mute Button - Always Visible for every Short */}
               {currentShort ? (
@@ -4237,12 +4242,16 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
                   style={styles.topBarButton}
                   onPress={() => {
                     if (!currentShort) return;
-                    setMutedShorts(prev => {
-                      const next = new Set(prev);
-                      if (next.has(currentShort._id)) next.delete(currentShort._id);
-                      else next.add(currentShort._id);
-                      return next;
-                    });
+                    if (props.onMuteToggle) {
+                      props.onMuteToggle();
+                    } else {
+                      setMutedShorts(prev => {
+                        const next = new Set(prev);
+                        if (next.has(currentShort._id)) next.delete(currentShort._id);
+                        else next.add(currentShort._id);
+                        return next;
+                      });
+                    }
                   }}
                   accessibilityLabel={isMuted ? 'Unmute' : 'Mute'}
                   accessibilityRole="button"
@@ -4903,7 +4912,7 @@ const styles = StyleSheet.create({
     width: 40,
     height: 40,
     borderRadius: 20,
-    backgroundColor: 'rgba(0, 0, 0, 0.3)',
+    backgroundColor: 'transparent',
     justifyContent: 'center',
     alignItems: 'center',
   },

--- a/frontend/app/(tabs)/shorts.tsx
+++ b/frontend/app/(tabs)/shorts.tsx
@@ -4624,17 +4624,11 @@ const styles = StyleSheet.create({
   actionIconContainer: {
     width: 48,
     height: 48,
-    borderRadius: 24,
-    backgroundColor: 'rgba(0, 0, 0, 0.45)',
     justifyContent: 'center',
     alignItems: 'center',
-    borderWidth: 0.5,
-    borderColor: 'rgba(255, 255, 255, 0.1)',
     marginBottom: isTablet ? 6 : 4,
   },
   likedContainer: {
-    borderColor: 'rgba(80, 200, 120, 0.25)',
-    backgroundColor: 'rgba(28, 115, 180, 0.08)',
   },
   actionText: {
     color: 'white',
@@ -4721,6 +4715,7 @@ const styles = StyleSheet.create({
     borderWidth: 2.5,
     borderColor: 'rgba(0,0,0,0.8)',
     backgroundColor: 'transparent',
+    opacity: 0,
   },
   userDetails: {
     flex: 1,

--- a/frontend/app/(tabs)/shorts.tsx
+++ b/frontend/app/(tabs)/shorts.tsx
@@ -54,6 +54,7 @@ import Constants from 'expo-constants';
 import { savedEvents } from '../../utils/savedEvents';
 import { triggerHaptic } from '../../utils/hapticFeedback';
 import { shortsEvents } from '../../utils/shortsEvents';
+import { preloadVideoAsync, getLocalVideoUri, removeCachedVideo } from '../../src/utils/videoCache';
 
 /** Shorts list item: either a reel (PostType) or a full-screen native ad slot. */
 export type ShortsItem = PostType | { type: 'ad'; adIndex: number };
@@ -306,14 +307,22 @@ const ShortsProgressBar = ({
     const performSeek = () => {
       const video = getVideoRef();
       if (video) {
-        // Enforce frame-accurate seeking using precise tolerance options in expo-av
-        video.setPositionAsync(targetMs, {
-          toleranceMillisBefore: 0,
-          toleranceMillisAfter: 0,
-        }).catch(() => {});
+        if (forceSeek) {
+          // Enforce frame-accurate seeking using precise tolerance options on touch start/end
+          video.setPositionAsync(targetMs, {
+            toleranceMillisBefore: 0,
+            toleranceMillisAfter: 0,
+          }).catch(() => {});
+        } else {
+          // Fast seek during active drag to avoid UI stuttering
+          video.setPositionAsync(targetMs).catch(() => {});
+        }
       }
-      if (hasMusic && currentPlayerRef.current) {
+      if (forceSeek && hasMusic && currentPlayerRef.current) {
         // Audio seek does not use tolerance parameters (to prevent codec rejection errors)
+        // We only seek the background audio player on initial touch (forceSeek = true)
+        // because the final seek is handled separately on touch end.
+        // This avoids audio thread clogging during active drag.
         currentPlayerRef.current.setPositionAsync(finalAudioMs).catch(() => {});
       }
       // Update lastVideoPosition immediately to prevent false loop detection triggers
@@ -329,7 +338,7 @@ const ShortsProgressBar = ({
       performSeek();
     } else {
       const timeSinceLastSeek = now - lastSeekTimeRef.current;
-      const throttleDelay = velocity > 0.5 ? 150 : 40;
+      const throttleDelay = 80; // Fixed 80ms throttle window for continuous seeks
       
       if (timeSinceLastSeek > throttleDelay) {
         if (pendingSeekTimeoutRef.current) {
@@ -888,6 +897,8 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
   const [showSwipeHint, setShowSwipeHint] = useState(true);
   const [videoQuality, setVideoQuality] = useState<'low' | 'medium' | 'high'>('high');
   const [expandedCaptions, setExpandedCaptions] = useState<{ [key: string]: boolean }>({});
+  const [localVideoUris, setLocalVideoUris] = useState<Record<string, string>>({});
+  const activeStartedWithRemoteRef = useRef<Record<string, boolean>>({});
 
   useEffect(() => {
     const unsubscribeViews = realtimePostsService.subscribeToViews(({ postId, viewsCount }) => {
@@ -1552,21 +1563,7 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
     return () => clearInterval(interval);
   }, []);
 
-  // Cleanup videos that are far from viewport
-  // Uses centralized stopAndUnloadVideo helper
-  useEffect(() => {
-    const cleanupDistance = 2; // Cleanup videos more than 1 position away (since we keep prev/current/next)
-    Object.keys(videoRefs.current).forEach((videoId) => {
-      const videoIndex = shorts.findIndex(s => s._id === videoId);
-      if (videoIndex === -1) return;
-      
-      const distance = Math.abs(videoIndex - currentVisibleIndex);
-      if (distance > cleanupDistance) {
-        // Use centralized helper to ensure proper cleanup
-        stopAndUnloadVideo(videoId);
-      }
-    });
-  }, [currentVisibleIndex, shorts, stopAndUnloadVideo]);
+  // Note: Cleanup, preloading, and remote URL tracking effects moved lower (after shortsData declaration)
 
   // Video cache for offline support
   const videoCacheRef = useRef<Map<string, { url: string; timestamp: number }>>(new Map());
@@ -1576,9 +1573,15 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
   // Priority: videoUrl > mediaUrl > imageUrl (for shorts, videoUrl should always be present)
   // CRITICAL: Signed URLs expire after 15 minutes, so cache is limited to 10 minutes
   const getVideoUrl = useCallback((item: PostType) => {
+    const videoId = item._id;
+
+    // Return local URI if available and we didn't start playing with a remote URL
+    if (localVideoUris[videoId] && !activeStartedWithRemoteRef.current[videoId]) {
+      return localVideoUris[videoId];
+    }
+
     // Prioritize videoUrl for shorts, fallback to mediaUrl or imageUrl
     const baseUrl = item.videoUrl || item.mediaUrl || item.imageUrl;
-    const videoId = item._id;
     
     // DETAILED LOGGING: Track URL resolution for first 2 shorts
     const isFirstTwoShorts = shorts.length > 0 && shorts.indexOf(item) < 2;
@@ -1680,7 +1683,7 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
     }
     logger.debug(`Video URL for ${videoId} (fresh):`, url.substring(0, 100) + '...');
     return url;
-  }, [videoQuality, shorts]);
+  }, [videoQuality, shorts, localVideoUris]);
   
   // Track previous visible index to detect actual scroll changes
   const previousVisibleIndexRef = useRef<number>(-1);
@@ -2831,6 +2834,97 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
     return result;
   }, [shorts, showShortsAds, adsShownThisSession, adCap.remainingSlots, failedAdIndices]);
 
+  // Cleanup videos that are far from viewport
+  // Uses centralized stopAndUnloadVideo helper
+  useEffect(() => {
+    const cleanupDistance = 2; // Cleanup videos more than 2 positions away (since we keep 5 mounted)
+    Object.keys(videoRefs.current).forEach((videoId) => {
+      const videoIndex = shortsData.findIndex(s => !isAdItem(s) && s._id === videoId);
+      if (videoIndex === -1) return;
+      
+      const distance = Math.abs(videoIndex - currentVisibleIndex);
+      if (distance > cleanupDistance) {
+        // Use centralized helper to ensure proper cleanup
+        stopAndUnloadVideo(videoId);
+        // Clean up from tracking refs to free memory
+        delete activeStartedWithRemoteRef.current[videoId];
+      }
+    });
+  }, [currentVisibleIndex, shortsData, stopAndUnloadVideo]);
+
+  // Sliding-Window Preloading and Local Cache Resolution Effect
+  useEffect(() => {
+    if (!shortsData || shortsData.length === 0) return;
+
+    const minIndex = Math.max(0, currentVisibleIndex - 2);
+    const maxIndex = Math.min(shortsData.length - 1, currentVisibleIndex + 2);
+
+    // 1. Trigger background preloading for all videos in the sliding window
+    for (let i = minIndex; i <= maxIndex; i++) {
+      const item = shortsData[i];
+      if (item && !isAdItem(item)) {
+        const baseUrl = item.videoUrl || item.mediaUrl || item.imageUrl;
+        if (baseUrl) {
+          preloadVideoAsync(item._id, baseUrl);
+        }
+      }
+    }
+
+    // 2. Poll/check file existence for the sliding window to update localVideoUris state
+    let active = true;
+    const checkCachedVideos = async () => {
+      const newUris: Record<string, string> = {};
+      for (let i = minIndex; i <= maxIndex; i++) {
+        const item = shortsData[i];
+        if (item && !isAdItem(item)) {
+          const localUri = await getLocalVideoUri(item._id);
+          if (localUri) {
+            newUris[item._id] = localUri;
+          }
+        }
+      }
+      if (active) {
+        setLocalVideoUris(prev => {
+          let changed = false;
+          const merged = { ...prev };
+          for (const id of Object.keys(newUris)) {
+            if (prev[id] !== newUris[id]) {
+              merged[id] = newUris[id];
+              changed = true;
+            }
+          }
+          if (changed) {
+            return merged;
+          }
+          return prev;
+        });
+      }
+    };
+
+    checkCachedVideos();
+    const interval = setInterval(checkCachedVideos, 1000);
+
+    return () => {
+      active = false;
+      clearInterval(interval);
+    };
+  }, [currentVisibleIndex, shortsData]);
+
+  // Track if active video started with a remote URL when it became visible.
+  // This prevents reload stuttering / black flashes mid-playback when download finishes.
+  useEffect(() => {
+    if (!shortsData || shortsData.length === 0) return;
+    const visibleItem = shortsData[currentVisibleIndex];
+    if (visibleItem && !isAdItem(visibleItem)) {
+      const videoId = visibleItem._id;
+      // If it became visible and we don't have a cached local URI for it yet,
+      // it must have started playing with a remote URL. Mark it as such.
+      if (!localVideoUris[videoId]) {
+        activeStartedWithRemoteRef.current[videoId] = true;
+      }
+    }
+  }, [currentVisibleIndex, shortsData, localVideoUris]);
+
   // Deep link: scroll to specific short when effectiveShortId is set (URL or props). dataIndex accounts for ad slots when showShortsAds.
   useEffect(() => {
     if (!effectiveShortId || shorts.length === 0) return;
@@ -3116,7 +3210,7 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
     // three concurrent decoders (prev + current + next) is the sweet spot.
     // The cleanup effect at distance > 2 unloads anything further out, and
     // the blur handler unloads ALL decoders when the user leaves the tab.
-    const shouldRenderVideo = Math.abs(distanceFromVisible) <= 1;
+    const shouldRenderVideo = Math.abs(distanceFromVisible) <= 2;
 
     const videoState = videoStates[item._id];
     // Only treat the video as "playing" once it has actually reported playback
@@ -3284,6 +3378,16 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
                   // unmounts the old player and remounts a clean one with the new URL.
                   logger.error(`Video ${item._id} failed to load:`, error);
                   videoCacheRef.current.delete(item._id);
+                  if (localVideoUris[item._id]) {
+                    const pathToRemove = localVideoUris[item._id];
+                    setLocalVideoUris(prev => {
+                      const updated = { ...prev };
+                      delete updated[item._id];
+                      return updated;
+                    });
+                    removeCachedVideo(pathToRemove).catch(() => {});
+                  }
+                  delete activeStartedWithRemoteRef.current[item._id];
                   updateKeyedBool(setVideoStates, item._id, false);
 
                   const errorMessage = typeof error === 'string' ? error : (error as any)?.message || '';
@@ -3418,6 +3522,16 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
                     // Clear cache and retry if this is the current visible video
                     if (index === currentVisibleIndex) {
                       videoCacheRef.current.delete(item._id);
+                      if (localVideoUris[item._id]) {
+                        const pathToRemove = localVideoUris[item._id];
+                        setLocalVideoUris(prev => {
+                          const updated = { ...prev };
+                          delete updated[item._id];
+                          return updated;
+                        });
+                        removeCachedVideo(pathToRemove).catch(() => {});
+                      }
+                      delete activeStartedWithRemoteRef.current[item._id];
                     }
                   }
                 }}
@@ -3768,7 +3882,7 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
     // swipeAnimation / fadeAnimation are Animated.Value refs from useRef ---
     // their identity never changes, so they don't belong in the deps array.
     // Including them was harmless but signaled false volatility.
-  }, [currentVisibleIndex, videoStates, followStates, savedShorts, mutedShorts, currentUser, showPauseButton, showLikeAnimation, isScreenFocused, sourceVersions, containerHeight, expandedCaptions, isVideoPlaying]);
+  }, [currentVisibleIndex, videoStates, followStates, savedShorts, mutedShorts, currentUser, showPauseButton, showLikeAnimation, isScreenFocused, sourceVersions, containerHeight, expandedCaptions, isVideoPlaying, localVideoUris]);
 
   const keyExtractor = useCallback((item: ShortsItem) => {
     if (isAdItem(item)) return `ad-${item.adIndex}`;

--- a/frontend/app/(tabs)/shorts.tsx
+++ b/frontend/app/(tabs)/shorts.tsx
@@ -3356,7 +3356,10 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
       ]}>
           {/* Video Player with Gesture Handling */}
           <View
-            style={styles.videoContainer}
+            style={[
+              styles.videoContainer,
+              isScopedView ? styles.videoContainerScoped : styles.videoContainerTabbed
+            ]}
             onTouchStart={handlersRef.current.handleTouchStart}
             onTouchMove={handlersRef.current.handleTouchMove}
             onTouchEnd={(event) => handlersRef.current.handleTouchEnd(event, item.user._id)}
@@ -4355,7 +4358,12 @@ const styles = StyleSheet.create({
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
-    paddingTop: Platform.OS === 'ios' ? 24 : 16, // Move video a little lower
+  },
+  videoContainerTabbed: {
+    paddingTop: Platform.OS === 'ios' ? 94 : 86, // Move video lower to touch the bar
+  },
+  videoContainerScoped: {
+    paddingTop: Platform.OS === 'ios' ? 24 : 16,
   },
   shortVideo: {
     width: '100%',

--- a/frontend/app/(tabs)/shorts.tsx
+++ b/frontend/app/(tabs)/shorts.tsx
@@ -166,6 +166,89 @@ const getVideoSource = (uri: string | null | undefined) => {
   return videoSourceCache.get(uri);
 };
 
+interface MarqueeTextProps {
+  text: string;
+  style?: any;
+  containerStyle?: any;
+  icon?: React.ReactNode;
+}
+
+const MarqueeText = React.memo(({ text, style, containerStyle, icon }: MarqueeTextProps) => {
+  const animatedValue = useRef(new Animated.Value(0)).current;
+  const [textWidth, setTextWidth] = useState(0);
+  const [containerWidth, setContainerWidth] = useState(0);
+
+  useEffect(() => {
+    animatedValue.setValue(0);
+    if (textWidth > 0 && containerWidth > 0 && textWidth > containerWidth) {
+      const offset = textWidth - containerWidth + 24; // 24px extra buffer
+      
+      const startAnimation = () => {
+        Animated.loop(
+          Animated.sequence([
+            Animated.delay(1500),
+            Animated.timing(animatedValue, {
+              toValue: -offset,
+              duration: offset * 30, // 30ms per pixel
+              useNativeDriver: true,
+            }),
+            Animated.delay(1500),
+            Animated.timing(animatedValue, {
+              toValue: 0,
+              duration: offset * 30,
+              useNativeDriver: true,
+            }),
+          ])
+        ).start();
+      };
+
+      startAnimation();
+    }
+    return () => {
+      animatedValue.stopAnimation();
+    };
+  }, [textWidth, containerWidth, text]);
+
+  const onTextLayout = (e: any) => {
+    const { width } = e.nativeEvent.layout;
+    setTextWidth(width);
+  };
+
+  const onContainerLayout = (e: any) => {
+    const { width } = e.nativeEvent.layout;
+    setContainerWidth(width);
+  };
+
+  return (
+    <View 
+      style={[{ flexDirection: 'row', alignItems: 'center', overflow: 'hidden' }, containerStyle]}
+      onLayout={onContainerLayout}
+    >
+      {icon}
+      <View style={{ overflow: 'hidden', flex: 1, marginLeft: icon ? 6 : 0 }}>
+        <Animated.View
+          style={{
+            flexDirection: 'row',
+            transform: [{ translateX: animatedValue }],
+            alignSelf: 'flex-start',
+          }}
+        >
+          <Text
+            style={[style, { flexShrink: 0, flexGrow: 0 }]}
+            onLayout={onTextLayout}
+            numberOfLines={1}
+          >
+            {text}
+          </Text>
+        </Animated.View>
+      </View>
+    </View>
+  );
+});
+
+MarqueeText.displayName = 'MarqueeText';
+
+
 /**
  * Memo wrapper around a single shorts cell. The parent computes a small
  * `cacheKey` string of every state slice that affects this cell's rendered
@@ -792,10 +875,7 @@ const LocalShortsActionRail = React.memo(({
             <GradientIcon name="paper-plane-outline" size={28} />
           </View>
         </Pressable>
-      </View>
 
-      {/* Options Button (Three dots - placed next to the username row at the bottom) */}
-      <View style={[styles.optionsActionContainer, isScopedView && { bottom: Platform.OS === 'ios' ? 20 : 16 }]} pointerEvents="box-none">
         <Pressable
           style={styles.actionButton}
           onPress={handleOptionsPress}
@@ -3224,6 +3304,12 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
     const isSaved = savedShorts.has(item._id);
     const isLiked = item.isLiked || false;
     
+    const isScopedView = !!effectiveUserId || props.isSavedShorts;
+    const progressBottom = isScopedView ? (isWeb ? 8 : 20) : (isWeb ? 8 : 77);
+    const progressHeight = 24;
+    const clearance = 24;
+    const bottomContentOffset = progressBottom + progressHeight + clearance;
+    
     // Calculate pause button visibility and icon - isolated from like state to prevent flexing
     // Don't show pause button if like animation is showing
     // Only show play/pause overlay when the user explicitly taps. Previously
@@ -3261,7 +3347,13 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
 
     return (
       <ShortCellMemo cacheKey={cacheKey} render={() => (
-      <View style={[styles.shortItem, { height: containerHeight }]}>
+      <View style={[
+        styles.shortItem, 
+        { 
+          height: containerHeight,
+          paddingBottom: isScopedView ? 0 : TAB_BAR_HEIGHT,
+        }
+      ]}>
           {/* Video Player with Gesture Handling */}
           <View
             style={styles.videoContainer}
@@ -3290,8 +3382,10 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
               <View style={[
                 styles.shortVideo,
                 {
-                  width: videoDim.width,
-                  height: videoDim.height,
+                  width: '100%',
+                  height: undefined, // Override height: '100%' from styles.shortVideo
+                  aspectRatio: 9 / 16,
+                  maxHeight: '100%',
                   alignSelf: 'center',
                 }
               ]}>
@@ -3695,7 +3789,7 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
           <View 
             style={[
               styles.bottomContent, 
-              (!!effectiveUserId || props.isSavedShorts) && { bottom: isWeb ? 30 : 38, paddingBottom: 0 }
+              { bottom: bottomContentOffset }
             ]}
           >
             <LinearGradient
@@ -3715,85 +3809,30 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
                 accessibilityRole="button"
               >
                 <View style={styles.avatarContainer}>
-                <ExpoImage
-                  source={item.user.profilePic ? { uri: item.user.profilePic } : require('../../assets/avatars/male_avatar.png')}
-                  style={styles.userAvatar as ImageStyle}
-                  cachePolicy="memory-disk"
-                  placeholder={require('../../assets/avatars/male_avatar.png')}
-                  contentFit="cover"
-                  transition={200}
-                  onError={(e: any) => logger.warn('[shorts bottom avatar] load failed', {
-                    userId: item.user._id,
-                    url: item.user.profilePic?.substring(0, 120),
-                    error: e?.error || e?.nativeEvent?.error || String(e),
-                  })}
-                />
+                  <ExpoImage
+                    source={item.user.profilePic ? { uri: item.user.profilePic } : require('../../assets/avatars/male_avatar.png')}
+                    style={styles.userAvatar as ImageStyle}
+                    cachePolicy="memory-disk"
+                    placeholder={require('../../assets/avatars/male_avatar.png')}
+                    contentFit="cover"
+                    transition={200}
+                    onError={(e: any) => logger.warn('[shorts bottom avatar] load failed', {
+                      userId: item.user._id,
+                      url: item.user.profilePic?.substring(0, 120),
+                      error: e?.error || e?.nativeEvent?.error || String(e),
+                    })}
+                  />
                   <View style={styles.avatarRing} />
                 </View>
                 <View style={styles.userDetails}>
                   <View style={styles.usernameRow}>
-                  <Text style={styles.username}>{item.user.fullName}</Text>
+                    <Text style={styles.username}>@{item.user.username || item.user.fullName}</Text>
                     {isFollowing && (
                       <View style={styles.followingBadge}>
                         <Text style={styles.followingText}>Following</Text>
                       </View>
                     )}
                   </View>
-                  
-                  {/* Song - Instagram style inline */}
-                  {item.song?.songId && (() => {
-                    const song = item.song.songId;
-                    const songTitle = song.title || 'Unknown Song';
-                    const songArtist = song.artist || 'Unknown Artist';
-                    return (
-                      <View style={styles.inlineSong}>
-                        <Ionicons name="musical-notes" size={12} color="#38BDF8" />
-                        <Text style={styles.inlineSongText} numberOfLines={1}>
-                          {songTitle} · {songArtist}
-                        </Text>
-                      </View>
-                    );
-                  })()}
-                  
-                  {/* Location - Instagram style inline */}
-                  {item.location?.address && (() => {
-                    const handleLocationPress = async () => {
-                      try {
-                        const address = item.location?.address;
-                        if (address) {
-                          const coordinates = await geocodeAddress(address);
-                          if (coordinates) {
-                            router.push({
-                              pathname: '/map/current-location',
-                              params: {
-                                latitude: coordinates.latitude.toString(),
-                                longitude: coordinates.longitude.toString(),
-                                address,
-                              }
-                            });
-                          } else {
-                            router.push('/map/current-location');
-                          }
-                        }
-                      } catch (error) {
-                        logger.warn('Failed to geocode location:', error);
-                        router.push('/map/current-location');
-                      }
-                    };
-                    
-                    return (
-                      <TouchableOpacity 
-                        style={styles.inlineLocation} 
-                        onPress={handleLocationPress}
-                        activeOpacity={0.7}
-                      >
-                        <Ionicons name="location-outline" size={12} color="#38BDF8" />
-                        <Text style={styles.inlineLocationText} numberOfLines={1}>
-                          {item.location.address}
-                        </Text>
-                      </TouchableOpacity>
-                    );
-                  })()}
                   
                   {item.caption ? (() => {
                     const isExpanded = !!expandedCaptions[item._id];
@@ -3841,6 +3880,63 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
                       </TouchableOpacity>
                     );
                   })() : null}
+                  
+                  {/* Location - Instagram style inline */}
+                  {item.location?.address && (() => {
+                    const handleLocationPress = async (e: any) => {
+                      e.stopPropagation?.();
+                      try {
+                        const address = item.location?.address;
+                        if (address) {
+                          const coordinates = await geocodeAddress(address);
+                          if (coordinates) {
+                            router.push({
+                              pathname: '/map/current-location',
+                              params: {
+                                latitude: coordinates.latitude.toString(),
+                                longitude: coordinates.longitude.toString(),
+                                address,
+                              }
+                            });
+                          } else {
+                            router.push('/map/current-location');
+                          }
+                        }
+                      } catch (error) {
+                        logger.warn('Failed to geocode location:', error);
+                        router.push('/map/current-location');
+                      }
+                    };
+                    
+                    return (
+                      <TouchableOpacity 
+                        style={styles.inlineLocation} 
+                        onPress={handleLocationPress}
+                        activeOpacity={0.7}
+                      >
+                        <Ionicons name="location-outline" size={12} color="#38BDF8" />
+                        <Text style={styles.inlineLocationText} numberOfLines={1}>
+                          {item.location.address}
+                        </Text>
+                      </TouchableOpacity>
+                    );
+                  })()}
+
+                  {/* Song - scrolling marquee */}
+                  {item.song?.songId && (() => {
+                    const song = item.song.songId;
+                    const songTitle = song.title || 'Unknown Song';
+                    const songArtist = song.artist || 'Unknown Artist';
+                    const displayText = `${songTitle} · ${songArtist}`;
+                    return (
+                      <MarqueeText
+                        text={displayText}
+                        style={styles.inlineSongText}
+                        containerStyle={styles.inlineSong}
+                        icon={<Ionicons name="musical-notes" size={12} color="#38BDF8" />}
+                      />
+                    );
+                  })()}
                 </View>
               </TouchableOpacity>
               
@@ -4242,7 +4338,8 @@ const styles = StyleSheet.create({
   },
   shortItem: {
     width: '100%',
-    height: SHORTS_ITEM_HEIGHT,
+    flex: 1,
+    height: (isWeb ? '100vh' : Dimensions.get('window').height) as any,
     position: 'relative',
     backgroundColor: 'black',
   },
@@ -4256,8 +4353,9 @@ const styles = StyleSheet.create({
     position: 'relative',
     backgroundColor: 'black',
     display: 'flex',
-    justifyContent: 'flex-start',
+    justifyContent: 'center',
     alignItems: 'center',
+    paddingTop: Platform.OS === 'ios' ? 24 : 16, // Move video a little lower
   },
   shortVideo: {
     width: '100%',
@@ -4352,15 +4450,8 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     zIndex: 5,
   },
-  optionsActionContainer: {
-    position: 'absolute',
-    right: isTablet ? theme.spacing.lg : 12,
-    bottom: Platform.OS === 'ios' ? (isWeb ? 36 : 32) : (isWeb ? 32 : 32),
-    alignItems: 'center',
-    zIndex: 5,
-  },
   profileButton: {
-    marginBottom: isTablet ? theme.spacing.xl : 20,
+    marginBottom: 16,
     position: 'relative',
   },
   actionsAvatarContainer: {
@@ -4632,7 +4723,7 @@ const styles = StyleSheet.create({
     top: 0,
     left: 0,
     right: 0,
-    height: Platform.OS === 'ios' ? 100 : 80,
+    height: Platform.OS === 'ios' ? 80 : 64,
     zIndex: 100,
   },
   topBarContent: {
@@ -4640,7 +4731,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'space-between',
     paddingHorizontal: 16,
-    paddingTop: Platform.OS === 'ios' ? 50 : 36,
+    paddingTop: Platform.OS === 'ios' ? 36 : 20,
     height: '100%',
     width: '100%',
   },

--- a/frontend/app/(tabs)/shorts.tsx
+++ b/frontend/app/(tabs)/shorts.tsx
@@ -18,6 +18,7 @@ import {
   Pressable,
   RefreshControl,
   ActivityIndicator,
+  Easing,
 } from 'react-native';
 import LoadingGlobe from '../../components/LoadingGlobe';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -247,6 +248,137 @@ const MarqueeText = React.memo(({ text, style, containerStyle, icon }: MarqueeTe
 });
 
 MarqueeText.displayName = 'MarqueeText';
+
+interface CyclingMetadataProps {
+  song?: {
+    songId?: {
+      title?: string;
+      artist?: string;
+    } | string | null;
+  } | null;
+  location?: {
+    address?: string;
+  } | null;
+  onLocationPress: (e: any) => void;
+}
+
+const CyclingMetadata = React.memo(({ song, location, onLocationPress }: CyclingMetadataProps) => {
+  const songIdObj = typeof song?.songId === 'object' ? song?.songId : null;
+  const songTitle = songIdObj?.title;
+  const songArtist = songIdObj?.artist;
+  const hasSong = !!(songTitle || songArtist);
+  const hasLocation = !!location?.address;
+
+  // If neither is present, show nothing
+  if (!hasSong && !hasLocation) return null;
+
+  // If only one is present, show it statically without animation
+  if (hasSong && !hasLocation) {
+    const displayText = `${songTitle || 'Unknown Song'} · ${songArtist || 'Unknown Artist'}`;
+    return (
+      <View style={styles.cyclingContainer}>
+        <Ionicons name="musical-notes" size={12} color="#38BDF8" />
+        <Text style={styles.cyclingText} numberOfLines={1}>
+          {displayText}
+        </Text>
+      </View>
+    );
+  }
+
+  if (!hasSong && hasLocation) {
+    return (
+      <TouchableOpacity 
+        style={styles.cyclingContainer} 
+        onPress={onLocationPress}
+        activeOpacity={0.7}
+      >
+        <Ionicons name="location" size={12} color="#38BDF8" />
+        <Text style={styles.cyclingText} numberOfLines={1}>
+          {location.address}
+        </Text>
+      </TouchableOpacity>
+    );
+  }
+
+  // Both song and location are present -> cycle every 2 seconds
+  const [showLocation, setShowLocation] = useState(false);
+  const fadeAnim = useRef(new Animated.Value(1)).current;
+  const translateAnim = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      // Step 1: Fade out & Slide up
+      Animated.parallel([
+        Animated.timing(fadeAnim, {
+          toValue: 0,
+          duration: 300,
+          useNativeDriver: true,
+        }),
+        Animated.timing(translateAnim, {
+          toValue: -10,
+          duration: 300,
+          useNativeDriver: true,
+        }),
+      ]).start(() => {
+        // Step 2: Toggle content and position text below
+        setShowLocation(prev => !prev);
+        translateAnim.setValue(10);
+        
+        // Step 3: Fade in & Slide back to center
+        Animated.parallel([
+          Animated.timing(fadeAnim, {
+            toValue: 1,
+            duration: 300,
+            useNativeDriver: true,
+          }),
+          Animated.timing(translateAnim, {
+            toValue: 0,
+            duration: 300,
+            useNativeDriver: true,
+          }),
+        ]).start();
+      });
+    }, 2000); // 2 seconds delay
+
+    return () => clearInterval(interval);
+  }, []);
+
+  const songText = `${songTitle || 'Unknown Song'} · ${songArtist || 'Unknown Artist'}`;
+
+  return (
+    <Animated.View
+      style={[
+        styles.cyclingAnimatedWrapper,
+        {
+          opacity: fadeAnim,
+          transform: [{ translateY: translateAnim }],
+        }
+      ]}
+    >
+      {showLocation ? (
+        <TouchableOpacity 
+          style={styles.cyclingContainer} 
+          onPress={onLocationPress}
+          activeOpacity={0.7}
+        >
+          <Ionicons name="location" size={12} color="#38BDF8" />
+          <Text style={styles.cyclingText} numberOfLines={1}>
+            {location.address}
+          </Text>
+        </TouchableOpacity>
+      ) : (
+        <View style={styles.cyclingContainer}>
+          <Ionicons name="musical-notes" size={12} color="#38BDF8" />
+          <Text style={styles.cyclingText} numberOfLines={1}>
+            {songText}
+          </Text>
+        </View>
+      )}
+    </Animated.View>
+  );
+});
+
+CyclingMetadata.displayName = 'CyclingMetadata';
 
 
 /**
@@ -628,12 +760,14 @@ interface LocalShortsActionRailProps {
   onSharePress: (short: PostType) => void;
   onSavePress: (shortId: string) => void;
   isScopedView?: boolean;
+  isPlaying: boolean;
 }
 
 function GradientIcon({ name, size }: { name: any; size: number }) {
   return (
     <MaskedView
       style={{ width: size, height: size }}
+      pointerEvents="none"
       maskElement={
         <Ionicons name={name} size={size} color="#000000" />
       }
@@ -667,6 +801,7 @@ const LocalShortsActionRail = React.memo(({
   onSharePress,
   onSavePress,
   isScopedView,
+  isPlaying,
 }: LocalShortsActionRailProps) => {
   const [localIsLiked, setLocalIsLiked] = useState(initialIsLiked);
   const [localLikesCount, setLocalLikesCount] = useState(initialLikesCount);
@@ -676,6 +811,47 @@ const LocalShortsActionRail = React.memo(({
   const [showModal, setShowModal] = useState(false);
   const [loading, setLoading] = useState(false);
   const [likers, setLikers] = useState<any[]>([]);
+
+  // 360-degree rotation animation setup for the album art disc
+  const spinValue = useRef(new Animated.Value(0)).current;
+  const spinAnimRef = useRef<Animated.CompositeAnimation | null>(null);
+
+  useEffect(() => {
+    if (isPlaying) {
+      // Smooth linear looping rotation
+      spinValue.setValue(0);
+      spinAnimRef.current = Animated.loop(
+        Animated.timing(spinValue, {
+          toValue: 1,
+          duration: 4000, // 4 seconds for one full loop
+          useNativeDriver: true,
+          easing: Easing.linear,
+        })
+      );
+      spinAnimRef.current.start();
+    } else {
+      if (spinAnimRef.current) {
+        spinAnimRef.current.stop();
+        spinAnimRef.current = null;
+      }
+    }
+    return () => {
+      if (spinAnimRef.current) {
+        spinAnimRef.current.stop();
+      }
+    };
+  }, [isPlaying]);
+
+  const spin = spinValue.interpolate({
+    inputRange: [0, 1],
+    outputRange: ['0deg', '360deg'],
+  });
+
+  const albumArtSource = useMemo(() => {
+    const DEFAULT_ALBUM_ART = 'https://images.unsplash.com/photo-1514525253161-7a46d19cd819?q=80&w=120&auto=format&fit=crop';
+    const thumbnailUrl = short.song?.songId?.thumbnailUrl || (typeof short.song?.songId === 'object' && short.song?.songId?.thumbnailUrl);
+    return thumbnailUrl ? { uri: thumbnailUrl } : { uri: DEFAULT_ALBUM_ART };
+  }, [short.song]);
 
   useEffect(() => {
     setLocalIsLiked(initialIsLiked);
@@ -752,6 +928,7 @@ const LocalShortsActionRail = React.memo(({
   }, [onSharePress, short]);
 
   const handleOptionsPress = useCallback(() => {
+    logger.debug('Options menu pressed for short:', shortId);
     showOptions(
       'Reel Options',
       [
@@ -786,45 +963,21 @@ const LocalShortsActionRail = React.memo(({
     <View style={StyleSheet.absoluteFill} pointerEvents="box-none">
       {/* Vertical actions rail (moved higher, containing Profile, Like, Comment, Share) */}
       <View style={[styles.rightActions, isScopedView && { bottom: Platform.OS === 'ios' ? 94 : 88 }]} pointerEvents="box-none">
-        <TouchableOpacity
-          style={styles.profileButton}
-          onPress={handleProfilePressLocal}
-          activeOpacity={0.8}
-          accessibilityLabel={`View ${username || 'user'}'s profile`}
-          accessibilityRole="button"
-        >
-          <View style={styles.actionsAvatarContainer}>
-            <LinearGradient
-              colors={['#1C73B4', '#50C878']}
-              style={styles.actionsGradientBorder}
-              start={{ x: 0, y: 0 }}
-              end={{ x: 1, y: 1 }}
-            >
+        <View style={styles.profileButton}>
+          <Animated.View style={[styles.actionsAvatarContainer, { transform: [{ rotate: spin }] }]}>
+            <View style={styles.albumArtContainer}>
               <ExpoImage
-                source={profileSource}
-                style={styles.actionsProfileImage as ImageStyle}
+                source={albumArtSource}
+                style={styles.albumArtImage as ImageStyle}
                 cachePolicy="memory-disk"
-                placeholder={require('../../assets/avatars/male_avatar.png')}
+                placeholder={{ uri: 'https://images.unsplash.com/photo-1514525253161-7a46d19cd819?q=80&w=120&auto=format&fit=crop' }}
                 contentFit="cover"
                 transition={200}
-                onError={(e: any) => logger.warn('[shorts profile avatar] load failed', {
-                  userId,
-                  url: profilePic?.substring(0, 120),
-                  error: e?.error || e?.nativeEvent?.error || String(e),
-                })}
               />
-            </LinearGradient>
-            {currentUserLoaded && !isOwn && (
-              <View style={[styles.followButton, isFollowing && styles.followingButton]}>
-                <Ionicons
-                  name={isFollowing ? "checkmark" : "add"}
-                  size={12}
-                  color="white"
-                />
-              </View>
-            )}
-          </View>
-        </TouchableOpacity>
+              <View style={styles.albumArtInnerRing} />
+            </View>
+          </Animated.View>
+        </View>
 
         <View style={styles.actionButton}>
           <Pressable
@@ -876,16 +1029,17 @@ const LocalShortsActionRail = React.memo(({
           </View>
         </Pressable>
 
-        <Pressable
+        <TouchableOpacity
           style={styles.actionButton}
           onPress={handleOptionsPress}
           accessibilityLabel="More options"
           accessibilityRole="button"
+          activeOpacity={0.7}
         >
           <View style={styles.actionIconContainer}>
             <GradientIcon name="ellipsis-vertical" size={28} />
           </View>
-        </Pressable>
+        </TouchableOpacity>
       </View>
 
       {/* Likes Detail View Modal */}
@@ -3307,7 +3461,8 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
     const isScopedView = !!effectiveUserId || props.isSavedShorts;
     const progressBottom = isScopedView ? (isWeb ? 8 : 20) : (isWeb ? 8 : 77);
     const progressHeight = 24;
-    const clearance = 24;
+    const videoContainerBottom = progressBottom + progressHeight;
+    const clearance = 16;
     const bottomContentOffset = progressBottom + progressHeight + clearance;
     
     // Calculate pause button visibility and icon - isolated from like state to prevent flexing
@@ -3358,7 +3513,7 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
           <View
             style={[
               styles.videoContainer,
-              isScopedView ? styles.videoContainerScoped : styles.videoContainerTabbed
+              { bottom: videoContainerBottom }
             ]}
             onTouchStart={handlersRef.current.handleTouchStart}
             onTouchMove={handlersRef.current.handleTouchMove}
@@ -3384,13 +3539,7 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
                   the parent so taps still hit anywhere. */}
               <View style={[
                 styles.shortVideo,
-                {
-                  width: '100%',
-                  height: undefined, // Override height: '100%' from styles.shortVideo
-                  aspectRatio: 9 / 16,
-                  maxHeight: '100%',
-                  alignSelf: 'center',
-                }
+                StyleSheet.absoluteFillObject
               ]}>
               {/* Always show thumbnail backdrop so there's never a black surface.
                   The Video layers on top; once its first frame decodes, it
@@ -3399,7 +3548,7 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
                 <ExpoImage
                   source={{ uri: item.imageUrl }}
                   style={[styles.shortVideo as ImageStyle, StyleSheet.absoluteFillObject]}
-                  contentFit="contain"
+                  contentFit="cover"
                   cachePolicy="memory-disk"
                   transition={0}
                   onError={(e: any) => logger.warn('[shorts thumbnail] load failed', {
@@ -3433,7 +3582,7 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
                   styles.shortVideo,
                   StyleSheet.absoluteFillObject,
                 ]}
-                resizeMode={ResizeMode.CONTAIN}
+                resizeMode={ResizeMode.COVER}
                 shouldPlay={index === currentVisibleIndex && isVideoPlaying && !userPausedShortIdsRef.current.has(item._id)}
                 isLooping
                 progressUpdateIntervalMillis={100}
@@ -3786,6 +3935,7 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
             onSharePress={handlersRef.current.handleShare}
             onSavePress={handlersRef.current.handleSave}
             isScopedView={!!effectiveUserId || props.isSavedShorts}
+            isPlaying={isCellVideoPlaying}
           />
 
           {/* Bottom Content with Elegant Design */}
@@ -3801,92 +3951,64 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
             />
             
             <View style={styles.bottomContentInner}>
-              <TouchableOpacity
-                style={styles.userProfileSection}
-                onPress={(e) => {
-                  e.stopPropagation?.(); // Prevent event from bubbling
-                  handlersRef.current.handleProfilePress(item.user._id);
-                }}
-                activeOpacity={0.7}
-                accessibilityLabel={`View ${item.user.username || 'user'}'s profile`}
-                accessibilityRole="button"
-              >
-                <View style={styles.avatarContainer}>
-                  <ExpoImage
-                    source={item.user.profilePic ? { uri: item.user.profilePic } : require('../../assets/avatars/male_avatar.png')}
-                    style={styles.userAvatar as ImageStyle}
-                    cachePolicy="memory-disk"
-                    placeholder={require('../../assets/avatars/male_avatar.png')}
-                    contentFit="cover"
-                    transition={200}
-                    onError={(e: any) => logger.warn('[shorts bottom avatar] load failed', {
-                      userId: item.user._id,
-                      url: item.user.profilePic?.substring(0, 120),
-                      error: e?.error || e?.nativeEvent?.error || String(e),
-                    })}
-                  />
-                  <View style={styles.avatarRing} />
-                </View>
+              <View style={styles.userProfileSection}>
+                <TouchableOpacity
+                  style={styles.bottomAvatarContainer}
+                  onPress={(e) => {
+                    e.stopPropagation?.();
+                    handlersRef.current.handleProfilePress(item.user._id);
+                  }}
+                  activeOpacity={0.7}
+                  accessibilityLabel={`View ${item.user.username || 'user'}'s profile`}
+                  accessibilityRole="button"
+                >
+                  <LinearGradient
+                    colors={['#50C878', '#1C73B4']}
+                    style={styles.bottomGradientBorder}
+                    start={{ x: 0, y: 0 }}
+                    end={{ x: 1, y: 1 }}
+                  >
+                    <ExpoImage
+                      source={item.user.profilePic ? { uri: item.user.profilePic } : require('../../assets/avatars/male_avatar.png')}
+                      style={styles.bottomProfileImage as ImageStyle}
+                      cachePolicy="memory-disk"
+                      placeholder={require('../../assets/avatars/male_avatar.png')}
+                      contentFit="cover"
+                      transition={200}
+                      onError={(e: any) => logger.warn('[shorts bottom avatar] load failed', {
+                        userId: item.user._id,
+                        url: item.user.profilePic?.substring(0, 120),
+                        error: e?.error || e?.nativeEvent?.error || String(e),
+                      })}
+                    />
+                  </LinearGradient>
+                </TouchableOpacity>
+
                 <View style={styles.userDetails}>
+                  {/* Row 1 (Identity): A horizontal flex row containing the Username */}
                   <View style={styles.usernameRow}>
-                    <Text style={styles.username}>@{item.user.username || item.user.fullName}</Text>
+                    <TouchableOpacity
+                      onPress={(e) => {
+                        e.stopPropagation?.();
+                        handlersRef.current.handleProfilePress(item.user._id);
+                      }}
+                      activeOpacity={0.7}
+                    >
+                      <Text style={styles.username}>@{item.user.username || item.user._id}</Text>
+                    </TouchableOpacity>
+                    
                     {isFollowing && (
                       <View style={styles.followingBadge}>
                         <Text style={styles.followingText}>Following</Text>
                       </View>
                     )}
                   </View>
-                  
-                  {item.caption ? (() => {
-                    const isExpanded = !!expandedCaptions[item._id];
-                    const canExpand = item.caption.length > 80;
-                    const showTags = isExpanded;
-                    return (
-                      <TouchableOpacity 
-                        activeOpacity={0.9}
-                        onPress={(e) => {
-                          e.stopPropagation?.();
-                          setExpandedCaptions(prev => ({
-                            ...prev,
-                            [item._id]: !prev[item._id]
-                          }));
-                        }}
-                      >
-                        <Text 
-                          style={styles.caption} 
-                          numberOfLines={isExpanded ? undefined : 2}
-                        >
-                          {item.caption}
-                          {canExpand && !isExpanded && (
-                            <Text style={styles.moreText}> ...more</Text>
-                          )}
-                          {canExpand && isExpanded && (
-                            <Text style={styles.moreText}>  less</Text>
-                          )}
-                        </Text>
-                        
-                        {showTags && item.tags && item.tags.length > 0 && (
-                          <View style={styles.tagsContainer}>
-                            {item.tags.slice(0, 3).map((tag, tagIndex) => (
-                              <LinearGradient
-                                key={tagIndex}
-                                colors={['#1C73B4', '#50C878']}
-                                start={{ x: 0, y: 0 }}
-                                end={{ x: 1, y: 0 }}
-                                style={styles.tagBadgeGradient}
-                              >
-                                <Text style={styles.tagTextGradient}>#{tag}</Text>
-                              </LinearGradient>
-                            ))}
-                          </View>
-                        )}
-                      </TouchableOpacity>
-                    );
-                  })() : null}
-                  
-                  {/* Location - Instagram style inline */}
-                  {item.location?.address && (() => {
-                    const handleLocationPress = async (e: any) => {
+
+                  {/* Row 2 (Music & Location Cycling Carousel): Alternates every 2 seconds */}
+                  <CyclingMetadata
+                    song={item.song}
+                    location={item.location}
+                    onLocationPress={async (e) => {
                       e.stopPropagation?.();
                       try {
                         const address = item.location?.address;
@@ -3909,39 +4031,31 @@ export default function ShortsScreen(props: ShortsScreenProps = {}) {
                         logger.warn('Failed to geocode location:', error);
                         router.push('/map/current-location');
                       }
-                    };
-                    
-                    return (
-                      <TouchableOpacity 
-                        style={styles.inlineLocation} 
-                        onPress={handleLocationPress}
-                        activeOpacity={0.7}
-                      >
-                        <Ionicons name="location-outline" size={12} color="#38BDF8" />
-                        <Text style={styles.inlineLocationText} numberOfLines={1}>
-                          {item.location.address}
-                        </Text>
-                      </TouchableOpacity>
-                    );
-                  })()}
-
-                  {/* Song - scrolling marquee */}
-                  {item.song?.songId && (() => {
-                    const song = item.song.songId;
-                    const songTitle = song.title || 'Unknown Song';
-                    const songArtist = song.artist || 'Unknown Artist';
-                    const displayText = `${songTitle} · ${songArtist}`;
-                    return (
-                      <MarqueeText
-                        text={displayText}
-                        style={styles.inlineSongText}
-                        containerStyle={styles.inlineSong}
-                        icon={<Ionicons name="musical-notes" size={12} color="#38BDF8" />}
-                      />
-                    );
-                  })()}
+                    }}
+                  />
                 </View>
-              </TouchableOpacity>
+              </View>
+
+              {/* Row 3 (Caption Constraint): Toggles between 2 lines and expanded on press */}
+              {item.caption ? (
+                <TouchableOpacity
+                  activeOpacity={0.85}
+                  onPress={(e) => {
+                    e.stopPropagation?.();
+                    setExpandedCaptions(prev => ({
+                      ...prev,
+                      [item._id]: !prev[item._id]
+                    }));
+                  }}
+                >
+                  <Text 
+                    style={styles.caption} 
+                    numberOfLines={expandedCaptions[item._id] ? undefined : 2}
+                  >
+                    {item.caption}
+                  </Text>
+                </TouchableOpacity>
+              ) : null}
               
               {/* Song Player - Hidden but active for audio playback */}
               {/* CRITICAL: Only render SongPlayer if song exists with valid s3Url */}
@@ -4351,19 +4465,14 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
   },
   videoContainer: {
-    width: '100%',
-    height: '100%',
-    position: 'relative',
-    backgroundColor: 'black',
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: '#000000',
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
-  },
-  videoContainerTabbed: {
-    paddingTop: Platform.OS === 'ios' ? 94 : 86, // Move video lower to touch the bar
-  },
-  videoContainerScoped: {
-    paddingTop: Platform.OS === 'ios' ? 24 : 16,
   },
   shortVideo: {
     width: '100%',
@@ -4561,28 +4670,57 @@ const styles = StyleSheet.create({
   userProfileSection: {
     flexDirection: 'row',
     alignItems: 'flex-start',
-    marginBottom: 16,
+    marginBottom: 8,
   },
-  avatarContainer: {
-    position: 'relative',
+  bottomAvatarContainer: {
+    width: 48,
+    height: 48,
     marginRight: 14,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
-  userAvatar: {
+  bottomGradientBorder: {
     width: 48,
     height: 48,
     borderRadius: 24,
-    borderWidth: 2.5,
-    borderColor: 'rgba(255,255,255,0.9)',
+    padding: 2.5,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
-  avatarRing: {
+  bottomProfileImage: {
+    width: 43,
+    height: 43,
+    borderRadius: 21.5,
+    backgroundColor: '#333',
+  },
+  albumArtContainer: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    backgroundColor: '#000',
+    borderWidth: 2,
+    borderColor: '#222',
+    justifyContent: 'center',
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.5,
+    shadowRadius: 3,
+    elevation: 5,
+  },
+  albumArtImage: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+  },
+  albumArtInnerRing: {
     position: 'absolute',
-    top: -2,
-    left: -2,
-    right: -2,
-    bottom: -2,
-    borderRadius: 26,
-    borderWidth: 1.5,
-    borderColor: 'rgba(255,255,255,0.3)',
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+    borderWidth: 2.5,
+    borderColor: 'rgba(0,0,0,0.8)',
+    backgroundColor: 'transparent',
   },
   userDetails: {
     flex: 1,
@@ -4591,8 +4729,8 @@ const styles = StyleSheet.create({
   usernameRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginBottom: 4, // Reduced from 6 to move text up slightly
-    flexWrap: 'wrap',
+    marginBottom: 4,
+    flexWrap: 'nowrap',
   },
   username: {
     color: 'white',
@@ -4602,10 +4740,33 @@ const styles = StyleSheet.create({
     textShadowColor: 'rgba(0,0,0,0.8)',
     textShadowOffset: { width: 0, height: 1 },
     textShadowRadius: 3,
-    marginRight: isTablet ? theme.spacing.sm : 8,
+    marginRight: 6,
+    flexShrink: 1,
     ...(isWeb && {
       fontFamily: 'Inter, -apple-system, BlinkMacSystemFont, sans-serif',
     } as any),
+  },
+  cyclingContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    height: 20,
+  },
+  cyclingText: {
+    color: '#38BDF8',
+    fontSize: 14,
+    marginLeft: 6,
+    fontFamily: getFontFamily('400'),
+    textShadowColor: 'rgba(0,0,0,0.6)',
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 2,
+    ...(isWeb && {
+      fontFamily: 'Inter, -apple-system, BlinkMacSystemFont, sans-serif',
+    } as any),
+  },
+  cyclingAnimatedWrapper: {
+    height: 20,
+    justifyContent: 'center',
+    marginVertical: 4,
   },
   followingBadge: {
     backgroundColor: 'rgba(255,255,255,0.2)',
@@ -4629,8 +4790,8 @@ const styles = StyleSheet.create({
     fontSize: isTablet ? theme.typography.body.fontSize : 14,
     fontFamily: getFontFamily('400'),
     lineHeight: isTablet ? 22 : 20,
-    marginTop: 2, // Small margin to separate from location
-    marginBottom: isTablet ? theme.spacing.md : 8, // Reduced from 10 to move text up
+    marginTop: 6,
+    marginBottom: 0,
     textShadowColor: 'rgba(0,0,0,0.8)',
     textShadowOffset: { width: 0, height: 1 },
     textShadowRadius: 3,

--- a/frontend/app/connect/index.tsx
+++ b/frontend/app/connect/index.tsx
@@ -12,6 +12,7 @@ import {
   TextInput,
   Alert,
   KeyboardAvoidingView,
+  Modal,
 } from 'react-native';
 import LoadingGlobe from '../../components/LoadingGlobe';
 import { useRouter, useFocusEffect } from 'expo-router';
@@ -106,73 +107,88 @@ function PickerModal({
     : items;
 
   return (
-    <View style={[styles.pickerOverlay, { backgroundColor: 'rgba(0,0,0,0.5)' }]}>
-      <View style={[styles.pickerModal, { backgroundColor: theme.colors.surface }]}>
-        <View style={styles.pickerHeader}>
-          <Text style={[styles.pickerTitle, { color: theme.colors.text }]}>{title}</Text>
-          <TouchableOpacity onPress={onClose} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
-            <Ionicons name="close" size={24} color={theme.colors.text} />
-          </TouchableOpacity>
-        </View>
+    <Modal
+      animationType="fade"
+      transparent={true}
+      visible={true}
+      onRequestClose={onClose}
+    >
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        style={[styles.pickerOverlay, { backgroundColor: 'rgba(0,0,0,0.5)' }]}
+      >
+        <TouchableOpacity
+          style={StyleSheet.absoluteFillObject}
+          activeOpacity={1}
+          onPress={onClose}
+        />
+        <View style={[styles.pickerModal, { backgroundColor: theme.colors.surface, width: '100%' }]}>
+          <View style={styles.pickerHeader}>
+            <Text style={[styles.pickerTitle, { color: theme.colors.text }]}>{title}</Text>
+            <TouchableOpacity onPress={onClose} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+              <Ionicons name="close" size={24} color={theme.colors.text} />
+            </TouchableOpacity>
+          </View>
 
-        {/* Search input */}
-        <View style={[styles.pickerSearchWrap, { backgroundColor: theme.colors.background, borderColor: theme.colors.border }]}>
-          <Ionicons name="search" size={16} color={theme.colors.textSecondary} />
-          <TextInput
-            style={[styles.pickerSearchInput, { color: theme.colors.text }]}
-            value={query}
-            onChangeText={setQuery}
-            placeholder="Type to search…"
-            placeholderTextColor={theme.colors.textSecondary}
-            autoCorrect={false}
-            autoCapitalize="none"
-            returnKeyType="search"
-          />
-          {query.length > 0 && (
-            <TouchableOpacity onPress={() => setQuery('')} hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}>
-              <Ionicons name="close-circle" size={16} color={theme.colors.textSecondary} />
-            </TouchableOpacity>
-          )}
-        </View>
+          {/* Search input */}
+          <View style={[styles.pickerSearchWrap, { backgroundColor: theme.colors.background, borderColor: theme.colors.border }]}>
+            <Ionicons name="search" size={16} color={theme.colors.textSecondary} />
+            <TextInput
+              style={[styles.pickerSearchInput, { color: theme.colors.text }]}
+              value={query}
+              onChangeText={setQuery}
+              placeholder="Type to search…"
+              placeholderTextColor={theme.colors.textSecondary}
+              autoCorrect={false}
+              autoCapitalize="none"
+              returnKeyType="search"
+            />
+            {query.length > 0 && (
+              <TouchableOpacity onPress={() => setQuery('')} hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}>
+                <Ionicons name="close-circle" size={16} color={theme.colors.textSecondary} />
+              </TouchableOpacity>
+            )}
+          </View>
 
-        <ScrollView style={styles.pickerList} keyboardShouldPersistTaps="handled" showsVerticalScrollIndicator={false}>
-          {/* "Any" option always visible (only when not searching) */}
-          {!trimmed && (
-            <TouchableOpacity
-              style={[styles.pickerItem, !selected && { backgroundColor: theme.colors.primary + '15' }]}
-              onPress={() => { onSelect(''); onClose(); }}
-              activeOpacity={0.7}
-            >
-              <Text style={[styles.pickerItemText, { color: !selected ? theme.colors.primary : theme.colors.textSecondary }]}>
-                Any
-              </Text>
-            </TouchableOpacity>
-          )}
-          {filtered.map(item => (
-            <TouchableOpacity
-              key={item.code}
-              style={[styles.pickerItem, selected === item.code && { backgroundColor: theme.colors.primary + '15' }]}
-              onPress={() => { onSelect(item.code); onClose(); }}
-              activeOpacity={0.7}
-            >
-              <Text style={[styles.pickerItemText, { color: selected === item.code ? theme.colors.primary : theme.colors.text }]}>
-                {item.name}
-              </Text>
-              {selected === item.code && (
-                <Ionicons name="checkmark" size={20} color={theme.colors.primary} />
-              )}
-            </TouchableOpacity>
-          ))}
-          {trimmed && filtered.length === 0 && (
-            <View style={styles.pickerEmpty}>
-              <Text style={[styles.pickerItemText, { color: theme.colors.textSecondary }]}>
-                No matches
-              </Text>
-            </View>
-          )}
-        </ScrollView>
-      </View>
-    </View>
+          <ScrollView style={styles.pickerList} keyboardShouldPersistTaps="handled" showsVerticalScrollIndicator={false}>
+            {/* "Any" option always visible (only when not searching) */}
+            {!trimmed && (
+              <TouchableOpacity
+                style={[styles.pickerItem, !selected && { backgroundColor: theme.colors.primary + '15' }]}
+                onPress={() => { onSelect(''); onClose(); }}
+                activeOpacity={0.7}
+              >
+                <Text style={[styles.pickerItemText, { color: !selected ? theme.colors.primary : theme.colors.textSecondary }]}>
+                  Any
+                </Text>
+              </TouchableOpacity>
+            )}
+            {filtered.map(item => (
+              <TouchableOpacity
+                key={item.code}
+                style={[styles.pickerItem, selected === item.code && { backgroundColor: theme.colors.primary + '15' }]}
+                onPress={() => { onSelect(item.code); onClose(); }}
+                activeOpacity={0.7}
+              >
+                <Text style={[styles.pickerItemText, { color: selected === item.code ? theme.colors.primary : theme.colors.text }]}>
+                  {item.name}
+                </Text>
+                {selected === item.code && (
+                  <Ionicons name="checkmark" size={20} color={theme.colors.primary} />
+                )}
+              </TouchableOpacity>
+            ))}
+            {trimmed && filtered.length === 0 && (
+              <View style={styles.pickerEmpty}>
+                <Text style={[styles.pickerItemText, { color: theme.colors.textSecondary }]}>
+                  No matches
+                </Text>
+              </View>
+            )}
+          </ScrollView>
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
   );
 }
 
@@ -377,7 +393,7 @@ export default function ConnectHubScreen() {
     try {
       if (pNum === 1) {
         if (isRefresh) setConnectRefreshing(true);
-        else setMyPagesLoading(true);
+        else if (myPages.length === 0) setMyPagesLoading(true);
       } else {
         setConnectLoadingMore(true);
       }
@@ -404,7 +420,7 @@ export default function ConnectHubScreen() {
       setConnectRefreshing(false);
       setConnectLoadingMore(false);
     }
-  }, []);
+  }, [myPages]);
 
   const handleLoadMoreConnect = useCallback(() => {
     if (!connectLoadingMore && connectHasMore && !myPagesLoading) {
@@ -418,7 +434,7 @@ export default function ConnectHubScreen() {
     try {
       if (pNum === 1) {
         if (isRefresh) setRefreshing(true);
-        else setLoading(true);
+        else if (pages.length === 0) setLoading(true);
       }
       const response = await getCommunities(pNum, 20);
       if (response) {
@@ -434,7 +450,7 @@ export default function ConnectHubScreen() {
       setRefreshing(false);
       setLoadingMore(false);
     }
-  }, [activeTab]);
+  }, [activeTab, pages]);
 
   useFocusEffect(
     useCallback(() => {
@@ -446,7 +462,7 @@ export default function ConnectHubScreen() {
   const handleTabChange = (tab: TabType) => {
     if (tab === activeTab) return;
     setActiveTab(tab);
-    if (tab === 'community') {
+    if (tab === 'community' && pages.length === 0) {
       setPages([]);
       setPageNum(1);
       setHasMore(true);
@@ -680,7 +696,7 @@ export default function ConnectHubScreen() {
   // Connect tab — every user-created (non-admin) page on the platform,
   // followed entries first (global ranking from the backend), paginated.
   const renderConnectTab = () => {
-    if (myPagesLoading) {
+    if (myPagesLoading && myPages.length === 0) {
       return (
         <View style={styles.loadingContainer}>
           <LoadingGlobe size="large" color={theme.colors.primary} />
@@ -1029,7 +1045,7 @@ export default function ConnectHubScreen() {
   );
 
   const renderPageListTab = () => {
-    if (loading) {
+    if (loading && pages.length === 0) {
       return (
         <View style={styles.loadingContainer}>
           <LoadingGlobe size="large" color={theme.colors.primary} />
@@ -1130,7 +1146,15 @@ export default function ConnectHubScreen() {
         <PremiumSegmentedTabs tabs={tabs} value={activeTab} onChange={handleTabChange} style={styles.tabBar} />
 
         {/* Tab Content */}
-        {activeTab === 'connect' ? renderConnectTab() : activeTab === 'find' ? renderFindTab() : renderPageListTab()}
+        <View style={[styles.listSlot, activeTab === 'connect' ? null : styles.hidden]} pointerEvents={activeTab === 'connect' ? 'auto' : 'none'}>
+          {renderConnectTab()}
+        </View>
+        <View style={[styles.listSlot, activeTab === 'find' ? null : styles.hidden]} pointerEvents={activeTab === 'find' ? 'auto' : 'none'}>
+          {renderFindTab()}
+        </View>
+        <View style={[styles.listSlot, activeTab === 'community' ? null : styles.hidden]} pointerEvents={activeTab === 'community' ? 'auto' : 'none'}>
+          {renderPageListTab()}
+        </View>
       </View>
 
       {/* FAB — Create Connect Page (Connect tab only) */}
@@ -1208,6 +1232,12 @@ const styles = StyleSheet.create({
   tabBar: {
     marginHorizontal: isTablet ? themeConstants.spacing.xl : themeConstants.spacing.md,
     marginBottom: 10,
+  },
+  listSlot: {
+    flex: 1,
+  },
+  hidden: {
+    display: 'none',
   },
   loadingContainer: {
     flex: 1,

--- a/frontend/app/connect/page/[id].tsx
+++ b/frontend/app/connect/page/[id].tsx
@@ -902,6 +902,31 @@ export default function ConnectPageDetailScreen() {
     <View
       style={[styles.container, { backgroundColor: theme.colors.background }]}
     >
+      {/* Background Depth Layer */}
+      {page.bannerImage ? (
+        <Image
+          source={{ uri: optimizeCloudinaryUrl(page.bannerImage, { width: 200, height: 200 }) }}
+          style={[StyleSheet.absoluteFillObject, { opacity: isDark ? 0.12 : 0.22 }]}
+          resizeMode="cover"
+          blurRadius={Platform.OS === 'android' ? 25 : 50}
+        />
+      ) : page.profileImage ? (
+        <Image
+          source={{ uri: optimizeCloudinaryUrl(page.profileImage, { width: 200, height: 200 }) }}
+          style={[StyleSheet.absoluteFillObject, { opacity: isDark ? 0.12 : 0.22 }]}
+          resizeMode="cover"
+          blurRadius={Platform.OS === 'android' ? 25 : 50}
+        />
+      ) : null}
+      <LinearGradient
+        colors={
+          isDark
+            ? ['rgba(13, 17, 23, 0.92)', 'rgba(6, 8, 12, 0.98)']
+            : ['rgba(248, 250, 252, 0.85)', 'rgba(241, 245, 249, 0.95)']
+        }
+        style={StyleSheet.absoluteFillObject}
+      />
+
       {/* Floating Glass Header */}
       <View
         style={[
@@ -914,22 +939,23 @@ export default function ConnectPageDetailScreen() {
             zIndex: 100,
             paddingTop: insets.top,
             height: 52 + insets.top,
-            backgroundColor: 'rgba(15, 15, 15, 0.4)',
-            borderColor: 'rgba(255, 255, 255, 0.08)',
             borderWidth: 0,
             borderBottomWidth: 1,
+            borderColor: isDark ? 'rgba(255, 255, 255, 0.08)' : 'rgba(0, 0, 0, 0.05)',
+            backgroundColor: 'transparent',
           }
         ]}
       >
         <BlurView
-          intensity={85}
-          tint="dark"
+          intensity={75}
+          tint={isDark ? 'dark' : 'light'}
           style={StyleSheet.absoluteFillObject}
+          {...(Platform.OS === 'android' ? { experimentalBlurMethod: 'dimezisBlurView' as const } : {})}
         />
         <View
           style={[
             StyleSheet.absoluteFillObject,
-            { backgroundColor: 'rgba(15, 15, 15, 0.4)' }
+            { backgroundColor: isDark ? 'rgba(15, 15, 15, 0.35)' : 'rgba(255, 255, 255, 0.35)' }
           ]}
         />
         <View style={styles.headerInner}>
@@ -939,9 +965,9 @@ export default function ConnectPageDetailScreen() {
             hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
             activeOpacity={0.7}
           >
-            <Ionicons name="arrow-back" size={isTablet ? 28 : 24} color="#FFFFFF" />
+            <Ionicons name="arrow-back" size={isTablet ? 28 : 24} color={isDark ? '#FFFFFF' : '#000000'} />
           </TouchableOpacity>
-          <Text style={[styles.headerTitle, { color: '#FFFFFF' }]} numberOfLines={1}>
+          <Text style={[styles.headerTitle, { color: isDark ? '#FFFFFF' : '#000000' }]} numberOfLines={1}>
             {page.name}
           </Text>
           {isOwner ? (
@@ -964,7 +990,7 @@ export default function ConnectPageDetailScreen() {
               hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
               activeOpacity={0.7}
             >
-              <Ionicons name="ellipsis-horizontal" size={isTablet ? 26 : 22} color="#FFFFFF" />
+              <Ionicons name="ellipsis-horizontal" size={isTablet ? 26 : 22} color={isDark ? '#FFFFFF' : '#000000'} />
             </TouchableOpacity>
           ) : (
             <View style={styles.headerRight} />
@@ -974,13 +1000,13 @@ export default function ConnectPageDetailScreen() {
 
       <ScrollView
         style={styles.scrollContent}
-        contentContainerStyle={{ paddingTop: 52 + insets.top }}
+        contentContainerStyle={{ paddingTop: 0 }}
         showsVerticalScrollIndicator={false}
       >
         {/* Banner */}
         {page.bannerImage ? (
           <Image
-            source={{ uri: optimizeCloudinaryUrl(page.bannerImage, { width: 800, height: 300, quality: 'auto' }) }}
+            source={{ uri: optimizeCloudinaryUrl(page.bannerImage, { width: 800, height: 400, quality: 'auto' }) }}
             style={styles.bannerImage}
             resizeMode="cover"
           />
@@ -1013,26 +1039,68 @@ export default function ConnectPageDetailScreen() {
               intensity={50}
               tint={isDark ? 'dark' : 'light'}
               style={StyleSheet.absoluteFillObject}
+              {...(Platform.OS === 'android' ? { experimentalBlurMethod: 'dimezisBlurView' as const } : {})}
             />
             <Ionicons name="people-outline" size={32} color={isDark ? 'rgba(255,255,255,0.3)' : 'rgba(0,0,0,0.3)'} />
           </View>
         )}
 
+        {/* Profile Image Wrapper (rendered as sibling, positioned above/overlapping the profile section card) */}
+        <View style={[styles.profileImageWrapper, { position: 'relative', zIndex: 20, top: 0, marginBottom: -(isTablet ? 44 : 38) }]}>
+          {page.profileImage ? (
+            <Image
+              source={{ uri: optimizeCloudinaryUrl(page.profileImage, { width: 160, height: 160 }) }}
+              style={[styles.pageProfileImage, { borderColor: isDark ? 'rgba(255, 255, 255, 0.2)' : 'rgba(255, 255, 255, 0.8)' }]}
+            />
+          ) : (
+            <View style={[styles.pageProfileImagePlaceholder, { backgroundColor: isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.05)', borderColor: isDark ? 'rgba(255, 255, 255, 0.2)' : 'rgba(255, 255, 255, 0.8)' }]}>
+              <Ionicons name="people" size={36} color={theme.colors.primary + '60'} />
+            </View>
+          )}
+        </View>
+
         {/* Profile Section */}
-        <View style={[styles.profileSection, { backgroundColor: theme.colors.surface }]}>
-          {/* Profile image overlapping banner */}
-          <View style={styles.profileImageWrapper}>
-            {page.profileImage ? (
-              <Image
-                source={{ uri: optimizeCloudinaryUrl(page.profileImage, { width: 160, height: 160 }) }}
-                style={[styles.pageProfileImage, { borderColor: theme.colors.surface }]}
-              />
-            ) : (
-              <View style={[styles.pageProfileImagePlaceholder, { backgroundColor: theme.colors.background, borderColor: theme.colors.surface }]}>
-                <Ionicons name="people" size={36} color={theme.colors.primary + '60'} />
-              </View>
-            )}
-          </View>
+        <View
+          style={[
+            styles.profileSection,
+            {
+              overflow: 'hidden',
+              backgroundColor: 'transparent',
+              borderWidth: 1,
+              borderTopColor: isDark ? 'rgba(255, 255, 255, 0.2)' : 'rgba(255, 255, 255, 0.75)',
+              borderLeftColor: isDark ? 'rgba(255, 255, 255, 0.2)' : 'rgba(255, 255, 255, 0.75)',
+              borderBottomColor: isDark ? 'rgba(255, 255, 255, 0.06)' : 'rgba(255, 255, 255, 0.2)',
+              borderRightColor: isDark ? 'rgba(255, 255, 255, 0.06)' : 'rgba(255, 255, 255, 0.2)',
+              marginTop: 0,
+              paddingTop: isTablet ? 52 : 46,
+              ...Platform.select({
+                ios: {
+                  shadowColor: isDark ? '#000000' : '#1f2687',
+                  shadowOffset: { width: 0, height: 8 },
+                  shadowOpacity: isDark ? 0.12 : 0.07,
+                  shadowRadius: 32,
+                },
+                android: {
+                  elevation: 1,
+                },
+              }),
+            }
+          ]}
+        >
+          <BlurView
+            intensity={50}
+            tint={isDark ? 'dark' : 'light'}
+            style={StyleSheet.absoluteFillObject}
+            {...(Platform.OS === 'android' ? { experimentalBlurMethod: 'dimezisBlurView' as const } : {})}
+          />
+          <View
+            style={[
+              StyleSheet.absoluteFillObject,
+              {
+                backgroundColor: isDark ? 'rgba(15, 20, 30, 0.45)' : 'rgba(255, 255, 255, 0.45)',
+              }
+            ]}
+          />
 
           {/* Name & bio centered */}
           <View style={styles.profileInfo}>
@@ -1180,16 +1248,45 @@ export default function ConnectPageDetailScreen() {
             style={[
               styles.section,
               {
-                backgroundColor: isDark ? 'rgba(56, 189, 248, 0.04)' : 'rgba(28, 115, 180, 0.03)',
-                borderColor: isDark ? 'rgba(56, 189, 248, 0.15)' : 'rgba(28, 115, 180, 0.12)',
+                overflow: 'hidden',
+                backgroundColor: 'transparent',
                 borderWidth: 1,
+                borderTopColor: isDark ? 'rgba(255, 255, 255, 0.18)' : 'rgba(255, 255, 255, 0.7)',
+                borderLeftColor: isDark ? 'rgba(255, 255, 255, 0.18)' : 'rgba(255, 255, 255, 0.7)',
+                borderBottomColor: isDark ? 'rgba(255, 255, 255, 0.05)' : 'rgba(255, 255, 255, 0.2)',
+                borderRightColor: isDark ? 'rgba(255, 255, 255, 0.05)' : 'rgba(255, 255, 255, 0.2)',
                 paddingBottom: isTablet ? themeConstants.spacing.md : 12,
                 marginTop: isTablet ? 14 : 12,
+                ...Platform.select({
+                  ios: {
+                    shadowColor: isDark ? '#000000' : '#1f2687',
+                    shadowOffset: { width: 0, height: 8 },
+                    shadowOpacity: isDark ? 0.12 : 0.07,
+                    shadowRadius: 32,
+                  },
+                  android: {
+                    elevation: 1,
+                  },
+                }),
               }
             ]}
             onPress={() => router.push(`/connect/preview?pageId=${id}&section=website&pageName=${encodeURIComponent(page.name)}`)}
             activeOpacity={0.7}
           >
+            <BlurView
+              intensity={45}
+              tint={isDark ? 'dark' : 'light'}
+              style={StyleSheet.absoluteFillObject}
+              {...(Platform.OS === 'android' ? { experimentalBlurMethod: 'dimezisBlurView' as const } : {})}
+            />
+            <View
+              style={[
+                StyleSheet.absoluteFillObject,
+                {
+                  backgroundColor: isDark ? 'rgba(15, 20, 30, 0.45)' : 'rgba(255, 255, 255, 0.45)',
+                }
+              ]}
+            />
             <View style={[styles.sectionHeader, { marginBottom: 0 }]}>
               <View style={styles.sectionTitleRow}>
                 <View style={[styles.sectionIconWrap, { backgroundColor: isDark ? 'rgba(56, 189, 248, 0.15)' : 'rgba(28, 115, 180, 0.08)' }]}>
@@ -1215,16 +1312,45 @@ export default function ConnectPageDetailScreen() {
             style={[
               styles.section,
               {
-                backgroundColor: isDark ? 'rgba(80, 200, 120, 0.04)' : 'rgba(80, 200, 120, 0.03)',
-                borderColor: isDark ? 'rgba(80, 200, 120, 0.15)' : 'rgba(80, 200, 120, 0.12)',
+                overflow: 'hidden',
+                backgroundColor: 'transparent',
                 borderWidth: 1,
+                borderTopColor: isDark ? 'rgba(255, 255, 255, 0.18)' : 'rgba(255, 255, 255, 0.7)',
+                borderLeftColor: isDark ? 'rgba(255, 255, 255, 0.18)' : 'rgba(255, 255, 255, 0.7)',
+                borderBottomColor: isDark ? 'rgba(255, 255, 255, 0.05)' : 'rgba(255, 255, 255, 0.2)',
+                borderRightColor: isDark ? 'rgba(255, 255, 255, 0.05)' : 'rgba(255, 255, 255, 0.2)',
                 paddingBottom: isTablet ? themeConstants.spacing.md : 12,
-                marginTop: !page.features?.website ? (isTablet ? 14 : 12) : 0,
+                marginTop: !page.features?.website ? (isTablet ? 14 : 12) : 10,
+                ...Platform.select({
+                  ios: {
+                    shadowColor: isDark ? '#000000' : '#1f2687',
+                    shadowOffset: { width: 0, height: 8 },
+                    shadowOpacity: isDark ? 0.12 : 0.07,
+                    shadowRadius: 32,
+                  },
+                  android: {
+                    elevation: 1,
+                  },
+                }),
               }
             ]}
             onPress={handleOpenChat}
             activeOpacity={0.7}
           >
+            <BlurView
+              intensity={45}
+              tint={isDark ? 'dark' : 'light'}
+              style={StyleSheet.absoluteFillObject}
+              {...(Platform.OS === 'android' ? { experimentalBlurMethod: 'dimezisBlurView' as const } : {})}
+            />
+            <View
+              style={[
+                StyleSheet.absoluteFillObject,
+                {
+                  backgroundColor: isDark ? 'rgba(15, 20, 30, 0.45)' : 'rgba(255, 255, 255, 0.45)',
+                }
+              ]}
+            />
             <View style={[styles.sectionHeader, { marginBottom: 0 }]}>
               <View style={styles.sectionTitleRow}>
                 <View style={[styles.sectionIconWrap, { backgroundColor: isDark ? 'rgba(80, 200, 120, 0.15)' : 'rgba(80, 200, 120, 0.08)' }]}>
@@ -1251,15 +1377,26 @@ export default function ConnectPageDetailScreen() {
             style={[
               styles.section,
               {
-                backgroundColor: isCommunity
-                  ? (isDark ? 'rgba(245, 158, 11, 0.04)' : 'rgba(217, 119, 6, 0.03)')
-                  : (isDark ? 'rgba(56, 189, 248, 0.04)' : 'rgba(28, 115, 180, 0.03)'),
-                borderColor: isCommunity
-                  ? (isDark ? 'rgba(245, 158, 11, 0.15)' : 'rgba(217, 119, 6, 0.12)')
-                  : (isDark ? 'rgba(56, 189, 248, 0.15)' : 'rgba(28, 115, 180, 0.12)'),
+                overflow: 'hidden',
+                backgroundColor: 'transparent',
                 borderWidth: 1,
+                borderTopColor: isDark ? 'rgba(255, 255, 255, 0.18)' : 'rgba(255, 255, 255, 0.7)',
+                borderLeftColor: isDark ? 'rgba(255, 255, 255, 0.18)' : 'rgba(255, 255, 255, 0.7)',
+                borderBottomColor: isDark ? 'rgba(255, 255, 255, 0.05)' : 'rgba(255, 255, 255, 0.2)',
+                borderRightColor: isDark ? 'rgba(255, 255, 255, 0.05)' : 'rgba(255, 255, 255, 0.2)',
                 paddingBottom: isTablet ? themeConstants.spacing.md : 12,
-                marginTop: (!page.features?.website && !page.features?.groupChat) ? (isTablet ? 14 : 12) : 0,
+                marginTop: (!page.features?.website && !page.features?.groupChat) ? (isTablet ? 14 : 12) : 10,
+                ...Platform.select({
+                  ios: {
+                    shadowColor: isDark ? '#000000' : '#1f2687',
+                    shadowOffset: { width: 0, height: 8 },
+                    shadowOpacity: isDark ? 0.12 : 0.07,
+                    shadowRadius: 32,
+                  },
+                  android: {
+                    elevation: 1,
+                  },
+                }),
               }
             ]}
             onPress={() => {
@@ -1271,6 +1408,20 @@ export default function ConnectPageDetailScreen() {
             }}
             activeOpacity={0.7}
           >
+            <BlurView
+              intensity={45}
+              tint={isDark ? 'dark' : 'light'}
+              style={StyleSheet.absoluteFillObject}
+              {...(Platform.OS === 'android' ? { experimentalBlurMethod: 'dimezisBlurView' as const } : {})}
+            />
+            <View
+              style={[
+                StyleSheet.absoluteFillObject,
+                {
+                  backgroundColor: isDark ? 'rgba(15, 20, 30, 0.45)' : 'rgba(255, 255, 255, 0.45)',
+                }
+              ]}
+            />
             <View style={[styles.sectionHeader, { marginBottom: 0 }]}>
               <View style={styles.sectionTitleRow}>
                 <View
@@ -1923,11 +2074,11 @@ const styles = StyleSheet.create({
   },
   bannerImage: {
     width: '100%',
-    height: isTablet ? 200 : 150,
+    height: isTablet ? 320 : 250,
   },
   bannerPlaceholder: {
     width: '100%',
-    height: isTablet ? 200 : 150,
+    height: isTablet ? 320 : 250,
     justifyContent: 'center',
     alignItems: 'center',
   },
@@ -1980,17 +2131,13 @@ const styles = StyleSheet.create({
   // Profile Section
   profileSection: {
     marginHorizontal: isTablet ? themeConstants.spacing.lg : themeConstants.spacing.md,
-    marginTop: -(isTablet ? 44 : 38),
+    marginTop: 0,
     paddingTop: isTablet ? 52 : 46,
     paddingHorizontal: isTablet ? themeConstants.spacing.xl : themeConstants.spacing.lg,
     paddingBottom: isTablet ? themeConstants.spacing.xl : themeConstants.spacing.lg,
     borderRadius: isTablet ? 16 : 14,
   },
   profileImageWrapper: {
-    position: 'absolute',
-    top: -(isTablet ? 44 : 38),
-    left: 0,
-    right: 0,
     alignItems: 'center',
     zIndex: 10,
   },

--- a/frontend/app/connect/page/[id].tsx
+++ b/frontend/app/connect/page/[id].tsx
@@ -187,6 +187,7 @@ export default function ConnectPageDetailScreen() {
   const [followers, setFollowers] = useState<ConnectFollowerUser[]>([]);
   const [followersLoading, setFollowersLoading] = useState(false);
   const [subscriptionStatus, setSubscriptionStatus] = useState<SubscriptionStatus | null>(null);
+  const [showSubscriptionManagementModal, setShowSubscriptionManagementModal] = useState(false);
   const [subscribing, setSubscribing] = useState(false);
   const [isRevealed, setIsRevealed] = useState(false);
   // Stores the pending subscription response so onVerify can optimistically
@@ -375,6 +376,18 @@ export default function ConnectPageDetailScreen() {
       loadPageDetail();
     }
   }, [subscription_return, page, isOwner, loadSubscriptionStatus, loadPageDetail]);
+
+  const getNextBillingDate = () => {
+    if (subscriptionStatus?.subscription?.currentPeriodEnd) {
+      return new Date(subscriptionStatus.subscription.currentPeriodEnd).toLocaleDateString();
+    }
+    if (subscriptionStatus?.subscription?.activatedAt) {
+      const activated = new Date(subscriptionStatus.subscription.activatedAt);
+      activated.setMonth(activated.getMonth() + 1);
+      return activated.toLocaleDateString();
+    }
+    return '4/7/2026';
+  };
 
   const handleSubscribe = async () => {
     if (!page || subscribing) return;
@@ -894,31 +907,30 @@ export default function ConnectPageDetailScreen() {
         style={[
           styles.headerContainer,
           {
-            backgroundColor: isDark ? 'rgba(0, 0, 0, 0.8)' : 'rgba(255, 255, 255, 0.8)',
-            borderColor: isDark ? 'rgba(255, 255, 255, 0.08)' : 'rgba(28, 115, 180, 0.15)',
+            position: 'absolute',
+            left: 0,
+            right: 0,
             top: 0,
+            zIndex: 100,
             paddingTop: insets.top,
             height: 52 + insets.top,
-            marginTop: 0,
-            marginHorizontal: 0,
-            borderBottomLeftRadius: 24,
-            borderBottomRightRadius: 24,
-            borderTopLeftRadius: 0,
-            borderTopRightRadius: 0,
+            backgroundColor: 'rgba(15, 15, 15, 0.4)',
+            borderColor: 'rgba(255, 255, 255, 0.08)',
             borderWidth: 0,
             borderBottomWidth: 1,
-            shadowOpacity: isDark ? 0.3 : 0.1,
           }
         ]}
       >
         <BlurView
-          intensity={80}
-          tint={isDark ? 'dark' : 'light'}
+          intensity={85}
+          tint="dark"
           style={StyleSheet.absoluteFillObject}
         />
-        <LinearGradient
-          colors={isDark ? ['rgba(255, 255, 255, 0.1)', 'transparent'] : ['rgba(255, 255, 255, 0.5)', 'transparent']}
-          style={StyleSheet.absoluteFillObject}
+        <View
+          style={[
+            StyleSheet.absoluteFillObject,
+            { backgroundColor: 'rgba(15, 15, 15, 0.4)' }
+          ]}
         />
         <View style={styles.headerInner}>
           <TouchableOpacity
@@ -927,9 +939,9 @@ export default function ConnectPageDetailScreen() {
             hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
             activeOpacity={0.7}
           >
-            <Ionicons name="arrow-back" size={isTablet ? 28 : 24} color={theme.colors.text} />
+            <Ionicons name="arrow-back" size={isTablet ? 28 : 24} color="#FFFFFF" />
           </TouchableOpacity>
-          <Text style={[styles.headerTitle, { color: theme.colors.text }]} numberOfLines={1}>
+          <Text style={[styles.headerTitle, { color: '#FFFFFF' }]} numberOfLines={1}>
             {page.name}
           </Text>
           {isOwner ? (
@@ -952,7 +964,7 @@ export default function ConnectPageDetailScreen() {
               hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
               activeOpacity={0.7}
             >
-              <Ionicons name="ellipsis-horizontal" size={isTablet ? 26 : 22} color={theme.colors.text} />
+              <Ionicons name="ellipsis-horizontal" size={isTablet ? 26 : 22} color="#FFFFFF" />
             </TouchableOpacity>
           ) : (
             <View style={styles.headerRight} />
@@ -960,7 +972,11 @@ export default function ConnectPageDetailScreen() {
         </View>
       </View>
 
-      <ScrollView style={styles.scrollContent} showsVerticalScrollIndicator={false}>
+      <ScrollView
+        style={styles.scrollContent}
+        contentContainerStyle={{ paddingTop: 52 + insets.top }}
+        showsVerticalScrollIndicator={false}
+      >
         {/* Banner */}
         {page.bannerImage ? (
           <Image
@@ -1246,7 +1262,13 @@ export default function ConnectPageDetailScreen() {
                 marginTop: (!page.features?.website && !page.features?.groupChat) ? (isTablet ? 14 : 12) : 0,
               }
             ]}
-            onPress={() => router.push(`/connect/preview?pageId=${id}&section=subscription&pageName=${encodeURIComponent(page.name)}`)}
+            onPress={() => {
+              if (subscriptionStatus?.isSubscribed) {
+                setShowSubscriptionManagementModal(true);
+              } else {
+                router.push(`/connect/preview?pageId=${id}&section=subscription&pageName=${encodeURIComponent(page.name)}`);
+              }
+            }}
             activeOpacity={0.7}
           >
             <View style={[styles.sectionHeader, { marginBottom: 0 }]}>
@@ -1801,6 +1823,84 @@ export default function ConnectPageDetailScreen() {
             </ScrollView>
           </View>
         </KeyboardAvoidingView>
+      </Modal>
+
+      {/* Subscription Management Bottom Sheet Modal */}
+      <Modal
+        visible={showSubscriptionManagementModal}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setShowSubscriptionManagementModal(false)}
+      >
+        <View style={styles.bottomSheetOverlay}>
+          <Pressable style={StyleSheet.absoluteFillObject} onPress={() => setShowSubscriptionManagementModal(false)} />
+          <View style={[styles.bottomSheetContent, { backgroundColor: theme.colors.surface, borderColor: theme.colors.border }]}>
+            <View style={styles.bottomSheetDragHandle} />
+            
+            <View style={styles.bottomSheetHeader}>
+              <Text style={[styles.bottomSheetTitle, { color: theme.colors.text }]}>
+                {isCommunity ? 'Purchase Details' : 'Subscription Status'}
+              </Text>
+              <TouchableOpacity
+                onPress={() => setShowSubscriptionManagementModal(false)}
+                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              >
+                <Ionicons name="close" size={24} color={theme.colors.text} />
+              </TouchableOpacity>
+            </View>
+
+            <View style={styles.bottomSheetStatusContainer}>
+              <View style={[styles.statusBadge, { backgroundColor: (theme.colors as any).success + '15' }]}>
+                <Ionicons name="checkmark-circle" size={20} color={(theme.colors as any).success} />
+                <Text style={[styles.statusBadgeText, { color: (theme.colors as any).success }]}>
+                  {subscriptionStatus?.subscription?.status === 'cancelled'
+                    ? 'Ending Soon'
+                    : (isCommunity ? 'Purchased' : 'Active')}
+                </Text>
+              </View>
+            </View>
+
+            <View style={styles.bottomSheetInfoContainer}>
+              <Text style={[styles.billingDateText, { color: theme.colors.textSecondary }]}>
+                {subscriptionStatus?.subscription?.status === 'cancelled'
+                  ? 'Access expires: ' + getNextBillingDate()
+                  : (isCommunity ? 'Next payment date: ' : 'Next billing date: ') + getNextBillingDate()}
+              </Text>
+            </View>
+
+            <TouchableOpacity
+              style={[styles.viewContentButton, { overflow: 'hidden' }]}
+              onPress={() => {
+                setShowSubscriptionManagementModal(false);
+                router.push(`/connect/preview?pageId=${id}&section=subscription&pageName=${encodeURIComponent(page.name)}`);
+              }}
+              activeOpacity={0.7}
+            >
+              <LinearGradient
+                colors={['#50C878', '#1C73B4']}
+                style={StyleSheet.absoluteFillObject}
+                start={{ x: 0, y: 0 }}
+                end={{ x: 1, y: 1 }}
+              />
+              <Text style={styles.viewContentButtonText}>View Premium Content</Text>
+            </TouchableOpacity>
+
+            {subscriptionStatus?.subscription?.status !== 'cancelled' && (
+              <TouchableOpacity
+                style={styles.cancelSubscriptionButton}
+                onPress={() => {
+                  setShowSubscriptionManagementModal(false);
+                  handleCancelSubscription();
+                }}
+                activeOpacity={0.7}
+              >
+                <Text style={styles.cancelSubscriptionButtonText}>
+                  {isCommunity ? 'Cancel Purchase' : 'Cancel Subscription'}
+                </Text>
+              </TouchableOpacity>
+            )}
+          </View>
+        </View>
       </Modal>
     </View>
   );
@@ -2747,6 +2847,93 @@ const styles = StyleSheet.create({
     color: '#FFFFFF',
     fontSize: 16,
     fontWeight: '600',
+  },
+  bottomSheetOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'flex-end',
+  },
+  bottomSheetContent: {
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    borderWidth: 1,
+    borderBottomWidth: 0,
+    paddingHorizontal: 20,
+    paddingTop: 8,
+    paddingBottom: Platform.OS === 'ios' ? 40 : 30,
+    alignItems: 'center',
+    width: '100%',
+  },
+  bottomSheetDragHandle: {
+    width: 36,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: 'rgba(255, 255, 255, 0.15)',
+    alignSelf: 'center',
+    marginBottom: 16,
+  },
+  bottomSheetHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    width: '100%',
+    marginBottom: 20,
+  },
+  bottomSheetTitle: {
+    fontSize: 18,
+    fontFamily: getFontFamily('600'),
+    fontWeight: '600',
+  },
+  bottomSheetStatusContainer: {
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  statusBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 20,
+  },
+  statusBadgeText: {
+    fontSize: 15,
+    fontFamily: getFontFamily('600'),
+    fontWeight: '600',
+  },
+  bottomSheetInfoContainer: {
+    alignItems: 'center',
+    marginBottom: 24,
+  },
+  billingDateText: {
+    fontSize: 15,
+    fontFamily: getFontFamily('500'),
+    fontWeight: '500',
+  },
+  viewContentButton: {
+    width: '100%',
+    height: 52,
+    borderRadius: themeConstants.borderRadius.sm,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 16,
+  },
+  viewContentButtonText: {
+    color: '#FFFFFF',
+    fontSize: 15,
+    fontFamily: getFontFamily('600'),
+    fontWeight: '600',
+  },
+  cancelSubscriptionButton: {
+    paddingVertical: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  cancelSubscriptionButtonText: {
+    color: '#EF4444',
+    fontSize: 14,
+    fontFamily: getFontFamily('500'),
+    fontWeight: '500',
   },
 });
 

--- a/frontend/app/connect/preview.tsx
+++ b/frontend/app/connect/preview.tsx
@@ -82,7 +82,7 @@ const AR_MAP: Record<string, number> = { square: 1, landscape: 16 / 9, portrait:
 
 // inRow: paired side-by-side with another block (fixed 4:3 + cover)
 // inStack: stacked vertically in a mosaic column (fills flex:1 with cover)
-function PreviewImage({ uri, inRow, inStack, arOverride }: { uri: string; inRow?: boolean; inStack?: boolean; arOverride?: string }) {
+function PreviewImage({ uri, inRow, inStack, arOverride, blurRadius }: { uri: string; inRow?: boolean; inStack?: boolean; arOverride?: string; blurRadius?: number }) {
   const [aspectRatio, setAspectRatio] = useState<number>(4 / 3);
 
   useEffect(() => {
@@ -98,6 +98,7 @@ function PreviewImage({ uri, inRow, inStack, arOverride }: { uri: string; inRow?
         source={{ uri }}
         style={{ flex: 1, width: '100%', borderRadius: 8 }}
         resizeMode="cover"
+        blurRadius={blurRadius}
       />
     );
   }
@@ -106,6 +107,7 @@ function PreviewImage({ uri, inRow, inStack, arOverride }: { uri: string; inRow?
       source={{ uri }}
       style={[styles.imageBlock, { aspectRatio: resolvedAR }]}
       resizeMode="cover"
+      blurRadius={blurRadius}
     />
   );
 }
@@ -533,7 +535,7 @@ export default function ContentPreviewScreen() {
         case 'image':
           return block.content ? (
             <View key={block._id || index} style={blockRadius !== undefined ? { borderRadius: blockRadius, overflow: 'hidden' } : undefined}>
-              <PreviewImage uri={block.content} inRow={inRow} inStack={inStack} arOverride={block.aspectRatio} />
+              <PreviewImage uri={block.content} inRow={inRow} inStack={inStack} arOverride={block.aspectRatio} blurRadius={isLocked ? 25 : undefined} />
             </View>
           ) : null;
         case 'video':
@@ -620,14 +622,37 @@ export default function ContentPreviewScreen() {
         <View key={block._id || index} pointerEvents="none" style={{ position: 'relative', overflow: 'hidden', borderRadius: blockRadius ?? 12, marginBottom: 8 }}>
           {element}
           <BlurView
-            intensity={40}
-            tint="dark"
-            style={[StyleSheet.absoluteFillObject, { justifyContent: 'center', alignItems: 'center', backgroundColor: 'rgba(0,0,0,0.15)' }]}
+            intensity={45}
+            tint={isDark ? 'dark' : 'light'}
+            style={StyleSheet.absoluteFillObject}
+            {...(Platform.OS === 'android' ? { experimentalBlurMethod: 'dimezisBlurView' as const } : {})}
+          />
+          <View
+            style={{
+              ...StyleSheet.absoluteFillObject,
+              backgroundColor: isDark ? 'rgba(30, 30, 30, 0.45)' : 'rgba(245, 245, 245, 0.45)',
+              justifyContent: 'center',
+              alignItems: 'center',
+              zIndex: 10,
+            }}
           >
-            <View style={{ backgroundColor: 'rgba(0,0,0,0.5)', padding: 8, borderRadius: 20 }}>
-              <Ionicons name="lock-closed" size={18} color="#FFFFFF" />
+            <View
+              style={{
+                backgroundColor: isDark ? 'rgba(0, 0, 0, 0.5)' : 'rgba(255, 255, 255, 0.65)',
+                padding: 10,
+                borderRadius: 22,
+                borderWidth: 1,
+                borderColor: isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.05)',
+                shadowColor: '#000',
+                shadowOffset: { width: 0, height: 2 },
+                shadowOpacity: 0.15,
+                shadowRadius: 4,
+                elevation: 3,
+              }}
+            >
+              <Ionicons name="lock-closed" size={18} color={isDark ? '#FFFFFF' : '#000000'} />
             </View>
-          </BlurView>
+          </View>
         </View>
       );
     }
@@ -653,31 +678,30 @@ export default function ContentPreviewScreen() {
         style={[
           styles.headerContainer,
           {
-            backgroundColor: isDark ? 'rgba(0, 0, 0, 0.8)' : 'rgba(255, 255, 255, 0.8)',
-            borderColor: isDark ? 'rgba(255, 255, 255, 0.08)' : 'rgba(28, 115, 180, 0.15)',
+            position: 'absolute',
+            left: 0,
+            right: 0,
             top: 0,
+            zIndex: 100,
             paddingTop: insets.top,
             height: 52 + insets.top,
-            marginTop: 0,
-            marginHorizontal: 0,
-            borderBottomLeftRadius: 24,
-            borderBottomRightRadius: 24,
-            borderTopLeftRadius: 0,
-            borderTopRightRadius: 0,
+            backgroundColor: 'rgba(15, 15, 15, 0.4)',
+            borderColor: 'rgba(255, 255, 255, 0.08)',
             borderWidth: 0,
             borderBottomWidth: 1,
-            shadowOpacity: isDark ? 0.3 : 0.1,
           }
         ]}
       >
         <BlurView
-          intensity={80}
-          tint={isDark ? 'dark' : 'light'}
+          intensity={85}
+          tint="dark"
           style={StyleSheet.absoluteFillObject}
         />
-        <LinearGradient
-          colors={isDark ? ['rgba(255, 255, 255, 0.1)', 'transparent'] : ['rgba(255, 255, 255, 0.5)', 'transparent']}
-          style={StyleSheet.absoluteFillObject}
+        <View
+          style={[
+            StyleSheet.absoluteFillObject,
+            { backgroundColor: 'rgba(15, 15, 15, 0.4)' }
+          ]}
         />
         <View style={styles.headerInner}>
           <TouchableOpacity
@@ -686,9 +710,9 @@ export default function ContentPreviewScreen() {
             hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
             activeOpacity={0.7}
           >
-            <Ionicons name="arrow-back" size={isTablet ? 28 : 24} color={textColor} />
+            <Ionicons name="arrow-back" size={isTablet ? 28 : 24} color="#FFFFFF" />
           </TouchableOpacity>
-          <Text style={[styles.headerTitle, { color: textColor }]} numberOfLines={1}>
+          <Text style={[styles.headerTitle, { color: '#FFFFFF' }]} numberOfLines={1}>
             {title}
           </Text>
           <View style={styles.headerRight}>
@@ -711,10 +735,10 @@ export default function ContentPreviewScreen() {
               </TouchableOpacity>
             ) : (
               <View
-                style={[styles.liveBadge, { backgroundColor: theme.colors.primary + '15' }]}
+                style={[styles.liveBadge, { backgroundColor: 'rgba(255, 255, 255, 0.15)' }]}
               >
-                <View style={[styles.liveDot, { backgroundColor: theme.colors.primary }]} />
-                <Text style={[styles.liveText, { color: theme.colors.primary }]}>Preview</Text>
+                <View style={[styles.liveDot, { backgroundColor: '#FFFFFF' }]} />
+                <Text style={[styles.liveText, { color: '#FFFFFF' }]}>Preview</Text>
               </View>
             )}
           </View>
@@ -734,7 +758,7 @@ export default function ContentPreviewScreen() {
       ) : (
         <ScrollView
           style={[styles.scrollContent, pageBackground ? { backgroundColor: pageBackground } : null]}
-          contentContainerStyle={[styles.contentContainer, { paddingTop: 56 + (isAndroid ? 6 : 4) + insets.top + 16 }]}
+          contentContainerStyle={[styles.contentContainer, { paddingTop: 52 + insets.top + 16 }]}
           showsVerticalScrollIndicator={false}
         >
           {/* Buy Items Listing for Community Category */}
@@ -867,32 +891,9 @@ export default function ContentPreviewScreen() {
               );
             }
 
-            // Visitor — already subscribed
+            // Visitor — already subscribed (purged from feed as billing logic resides in page details card modal)
             if (subscriptionStatus?.isSubscribed) {
-              return (
-                <View style={[styles.subscribeSection, { borderTopColor: theme.colors.border }]}>
-                  <View style={[styles.subscribedBadge, { backgroundColor: (theme.colors as any).success + '15' }]}>
-                    <Ionicons name="checkmark-circle" size={18} color={(theme.colors as any).success} />
-                    <Text style={[styles.subscribedText, { color: (theme.colors as any).success }]}>
-                      {isCommunity ? 'Purchased' : 'Subscribed'}
-                    </Text>
-                  </View>
-                  {subscriptionStatus.subscription?.currentPeriodEnd && (
-                    <Text style={[styles.subscribeNote, { color: theme.colors.textSecondary, fontStyle: 'normal' }]}>
-                      Renews {new Date(subscriptionStatus.subscription.currentPeriodEnd).toLocaleDateString()}
-                    </Text>
-                  )}
-                  <TouchableOpacity
-                    onPress={handleCancelSubscription}
-                    activeOpacity={0.7}
-                    style={{ marginTop: 8, paddingVertical: 4 }}
-                  >
-                    <Text style={{ color: theme.colors.error, fontSize: 13, fontFamily: getFontFamily('500'), fontWeight: '500' }}>
-                      {isCommunity ? 'Cancel purchase' : 'Cancel subscription'}
-                    </Text>
-                  </TouchableOpacity>
-                </View>
-              );
+              return null;
             }
 
             // Visitor — can subscribe (price approved)

--- a/frontend/app/map/all-locations.tsx
+++ b/frontend/app/map/all-locations.tsx
@@ -1544,7 +1544,12 @@ function initMap(){
             try {
               const data = JSON.parse(event.nativeEvent.data);
               if (data.type === 'navigatePost' && data.postId) {
-                router.push(`/post/${data.postId}`);
+                const targetUserId = data.userId || userId;
+                if (data.contentType === 'short') {
+                  router.push(`/user-shorts/${targetUserId}?shortId=${data.postId}`);
+                } else {
+                  router.push(`/post/${data.postId}`);
+                }
               } else if (data.type === 'selectLocation' && data.location) {
                 setSelectedLocation({
                   number: data.location.number,
@@ -1703,7 +1708,7 @@ function initMap(){
                 icon="location"
                 label={city}
                 activeTitle={city}
-                activeSubtitle="1 post"
+                activeSubtitle={location.contentType === 'short' ? '1 short' : '1 post'}
                 photo={location.photo}
                 latitudeDelta={safeLatitudeDelta}
               />
@@ -1989,13 +1994,23 @@ function initMap(){
                         </Text>
                         <View style={styles.previewActions}>
                           {item.postId ? (
-                            <TouchableOpacity
-                              style={[styles.previewButton, { borderColor: theme.colors.border }]}
-                              onPress={() => router.push(`/post/${item.postId}`)}
-                            >
-                              <Ionicons name="images-outline" size={16} color={theme.colors.text} />
-                              <Text style={[styles.previewButtonText, { color: theme.colors.text }]}>Post</Text>
-                            </TouchableOpacity>
+                            item.contentType === 'short' ? (
+                              <TouchableOpacity
+                                style={[styles.previewButton, { borderColor: theme.colors.border }]}
+                                onPress={() => router.push(`/user-shorts/${userId}?shortId=${item.postId}`)}
+                              >
+                                <Ionicons name="videocam-outline" size={16} color={theme.colors.text} />
+                                <Text style={[styles.previewButtonText, { color: theme.colors.text }]}>Shorts</Text>
+                              </TouchableOpacity>
+                            ) : (
+                              <TouchableOpacity
+                                style={[styles.previewButton, { borderColor: theme.colors.border }]}
+                                onPress={() => router.push(`/post/${item.postId}`)}
+                              >
+                                <Ionicons name="images-outline" size={16} color={theme.colors.text} />
+                                <Text style={[styles.previewButtonText, { color: theme.colors.text }]}>Post</Text>
+                              </TouchableOpacity>
+                            )
                           ) : null}
                           <TouchableOpacity
                             style={[styles.previewButton, styles.previewPrimaryButton, { backgroundColor: mapStyle.routeColor }]}
@@ -2513,7 +2528,7 @@ const styles = StyleSheet.create({
   previewImage: {
     width: 72,
     height: 72,
-    borderRadius: 16,
+    borderRadius: 36,
     overflow: 'hidden',
   },
   previewFallback: {

--- a/frontend/app/map/all-locations.tsx
+++ b/frontend/app/map/all-locations.tsx
@@ -598,20 +598,22 @@ function AllLocationsMapInner() {
   }, [validLocations, currentRegion]);
 
   const handleClusterPress = useCallback((cluster: any) => {
-    if (!mapRef.current) return;
+    if (!mapRef.current || useWebViewFallback) return;
     try {
       const coords = cluster.locations.map((loc: any) => ({
         latitude: loc.latitude,
         longitude: loc.longitude,
       }));
-      mapRef.current.fitToCoordinates(coords, {
-        edgePadding: { top: 100, right: 100, bottom: 100, left: 100 },
-        animated: true,
-      });
+      if (typeof mapRef.current.fitToCoordinates === 'function') {
+        mapRef.current.fitToCoordinates(coords, {
+          edgePadding: { top: 100, right: 100, bottom: 100, left: 100 },
+          animated: true,
+        });
+      }
     } catch (err) {
       logger.error('Error fitting to cluster coordinates:', err);
     }
-  }, []);
+  }, [useWebViewFallback]);
 
   const handleRegionChangeComplete = useCallback((newRegion: any) => {
     const safeRegion = sanitizeMapRegion(newRegion, currentRegion ?? undefined);
@@ -631,19 +633,31 @@ function AllLocationsMapInner() {
   const centerMapOnLocation = useCallback((latitude: number, longitude: number) => {
     if (!mapRef.current) return;
     try {
-      mapRef.current.animateToRegion(
-        {
-          latitude,
-          longitude,
-          latitudeDelta: 0.015,
-          longitudeDelta: 0.015,
-        },
-        400
-      );
+      if (useWebViewFallback) {
+        mapRef.current.injectJavaScript(`
+          if (window.map) {
+            window.map.panTo({ lat: ${latitude}, lng: ${longitude} });
+            window.map.setZoom(15);
+          }
+          true;
+        `);
+      } else {
+        if (typeof mapRef.current.animateToRegion === 'function') {
+          mapRef.current.animateToRegion(
+            {
+              latitude,
+              longitude,
+              latitudeDelta: 0.015,
+              longitudeDelta: 0.015,
+            },
+            400
+          );
+        }
+      }
     } catch (err) {
       logger.error('Error centering map on location:', err);
     }
-  }, []);
+  }, [useWebViewFallback]);
 
   const getCarouselItemLayout = useCallback((data: any, index: number) => ({
     length: screenWidth,
@@ -1055,12 +1069,14 @@ function AllLocationsMapInner() {
         const delay = Platform.OS === 'ios' ? (attempt === 0 ? 150 : 200) : (attempt === 0 ? 500 : 200);
         setTimeout(() => {
           try {
-            if (mapRef.current && allCoords.length > 0) {
-              mapRef.current.fitToCoordinates(allCoords, {
-                edgePadding: { top: 120, right: 80, bottom: 120, left: 80 },
-                animated: attempt === 0 && Platform.OS !== 'ios',
-              });
-              if (Platform.OS === 'ios' && attempt === 0) fitMap(1);
+            if (mapRef.current && allCoords.length > 0 && !useWebViewFallback) {
+              if (typeof mapRef.current.fitToCoordinates === 'function') {
+                mapRef.current.fitToCoordinates(allCoords, {
+                  edgePadding: { top: 120, right: 80, bottom: 120, left: 80 },
+                  animated: attempt === 0 && Platform.OS !== 'ios',
+                });
+                if (Platform.OS === 'ios' && attempt === 0) fitMap(1);
+              }
             }
           } catch (err) {
             if (attempt < 3) fitMap(attempt + 1);
@@ -1211,6 +1227,10 @@ html,body,#map{height:100%;margin:0;padding:0}
 .marker-thumb {
   width: 26px;
   height: 26px;
+  min-width: 26px;
+  min-height: 26px;
+  flex-shrink: 0;
+  -webkit-flex-shrink: 0;
   border-radius: 50%;
   object-fit: cover;
   border: 1.5px solid ${isDark ? '#2DD4BF' : '#3B82F6'};
@@ -1218,6 +1238,10 @@ html,body,#map{height:100%;margin:0;padding:0}
 .marker-thumb-placeholder {
   width: 26px;
   height: 26px;
+  min-width: 26px;
+  min-height: 26px;
+  flex-shrink: 0;
+  -webkit-flex-shrink: 0;
   border-radius: 50%;
   background: ${isDark ? 'rgba(45, 212, 191, 0.15)' : 'rgba(59, 130, 246, 0.1)'};
   display: flex;
@@ -1623,13 +1647,15 @@ function initMap(){
               j.polyline?.map((p) => ({ latitude: p.lat, longitude: p.lng })) || []
             ),
           ].filter(isValidMapCoordinate);
-          if (allCoords.length > 0 && mapRef.current) {
+          if (allCoords.length > 0 && mapRef.current && !useWebViewFallback) {
             setTimeout(() => {
               try {
-                mapRef.current?.fitToCoordinates(allCoords, {
-                  edgePadding: { top: 120, right: 80, bottom: 120, left: 80 },
-                  animated: false,
-                });
+                if (typeof mapRef.current?.fitToCoordinates === 'function') {
+                  mapRef.current.fitToCoordinates(allCoords, {
+                    edgePadding: { top: 120, right: 80, bottom: 120, left: 80 },
+                    animated: false,
+                  });
+                }
               } catch {}
             }, 300);
           }

--- a/frontend/app/map/current-location.tsx
+++ b/frontend/app/map/current-location.tsx
@@ -223,28 +223,8 @@ const resolvePhotoUrl = (url?: string | null): string | undefined => {
 };
 
 export default function CurrentLocationMap() {
-  const [location, setLocation] = useState<Location.LocationObject | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [isWatching, setIsWatching] = useState(false);
-  const [userCoords, setUserCoords] = useState<{ latitude: number; longitude: number } | null>(null);
-  const [latitudeDelta, setLatitudeDelta] = useState(0.1);
   const router = useRouter();
   const params = useLocalSearchParams();
-  const { theme, isDark } = useTheme();
-  const styles = useMemo(() => createStyles(isDark), [isDark]);
-  const insets = useSafeAreaInsets();
-  const mapStyle = useMapStyle();
-  const [route, setRoute] = useState<DirectionsRoute | null>(null);
-  const [routeLoading, setRouteLoading] = useState(false);
-  const [headerCardHeight, setHeaderCardHeight] = useState(60);
-  const hasLoggedParamsRef = useRef<string>('');
-  const mapRef = useRef<any>(null);
-
-  // Journey tracking UI (start / active / paused / instructions popup) was
-  // moved to /map/all-locations so it lives alongside past journeys, post
-  // pins and travel stats. This screen now focuses on showing the current
-  // location (or a post pin passed via params) with the directions button.
 
   // Check if we have location parameters (from locale or post)
   const postLatitude = params.latitude ? parseFloat(params.latitude as string) : null;
@@ -264,6 +244,39 @@ export default function CurrentLocationMap() {
                                postLatitude !== 0 && postLongitude !== 0;
   
   const isPostLocation = hasValidCoordinates; // Use valid coordinates check
+
+  const [location, setLocation] = useState<Location.LocationObject | null>(() => {
+    if (hasValidCoordinates) {
+      return {
+        coords: {
+          latitude: postLatitude!,
+          longitude: postLongitude!,
+          accuracy: 0,
+          altitude: null,
+          altitudeAccuracy: null,
+          heading: null,
+          speed: null,
+        },
+        timestamp: Date.now(),
+      } as Location.LocationObject;
+    }
+    return null;
+  });
+  const [loading, setLoading] = useState(!hasValidCoordinates);
+  const [error, setError] = useState<string | null>(null);
+  const [isWatching, setIsWatching] = useState(false);
+  const [userCoords, setUserCoords] = useState<{ latitude: number; longitude: number } | null>(null);
+  const [latitudeDelta, setLatitudeDelta] = useState(0.1);
+  const { theme, isDark } = useTheme();
+  const styles = useMemo(() => createStyles(isDark), [isDark]);
+  const insets = useSafeAreaInsets();
+  const mapStyle = useMapStyle();
+  const [route, setRoute] = useState<DirectionsRoute | null>(null);
+  const [routeLoading, setRouteLoading] = useState(false);
+  const [isRoutingActive, setIsRoutingActive] = useState(false);
+  const [headerCardHeight, setHeaderCardHeight] = useState(60);
+  const hasLoggedParamsRef = useRef<string>('');
+  const mapRef = useRef<any>(null);
 
   const [tracksViewChanges, setTracksViewChanges] = useState(true);
 
@@ -449,12 +462,34 @@ export default function CurrentLocationMap() {
   };
 
   const handleRefresh = () => {
-    getCurrentLocation();
+    if (isPostLocation && postLatitude && postLongitude) {
+      if (mapRef.current) {
+        if (useWebViewFallback) {
+          const jsCode = `
+            if (window.map) {
+              window.map.panTo({ lat: ${postLatitude}, lng: ${postLongitude} });
+              window.map.setZoom(15);
+            }
+          `;
+          mapRef.current.injectJavaScript(jsCode);
+        } else {
+          mapRef.current.animateToRegion({
+            latitude: postLatitude,
+            longitude: postLongitude,
+            latitudeDelta: 0.01,
+            longitudeDelta: 0.01,
+          }, 1000);
+        }
+      }
+    } else {
+      getCurrentLocation();
+    }
   };
 
   const loadRoute = async () => {
     if (!hasValidCoordinates || !postLatitude || !postLongitude) return;
     try {
+      setIsRoutingActive(true);
       setRouteLoading(true);
       let coords = userCoords;
       if (!coords) {
@@ -631,7 +666,8 @@ html,body,#map{height:100%;margin:0;padding:0}
 </style>
 <script>
 function initMap(){
-  var map=new google.maps.Map(document.getElementById('map'),{center:{lat:${lat},lng:${lng}},zoom:15,mapTypeId:'roadmap',language:'en',styles:${JSON.stringify(mapStyle.customMapStyle)},disableDefaultUI:true,zoomControl:true});
+  window.map=new google.maps.Map(document.getElementById('map'),{center:{lat:${lat},lng:${lng}},zoom:15,mapTypeId:'roadmap',language:'en',styles:${JSON.stringify(mapStyle.customMapStyle)},disableDefaultUI:true,zoomControl:true});
+  var map=window.map;
   
   // Custom OverlayView class
   class PhotoOverlay extends google.maps.OverlayView {
@@ -700,6 +736,7 @@ function initMap(){
 </body></html>`;
       return (
         <WebView
+          ref={mapRef}
           style={styles.map}
           source={{ html }}
           javaScriptEnabled={true}
@@ -936,7 +973,7 @@ function initMap(){
                     </Text>
                   </View>
                 )}
-                {isPostLocation && userCoords && (
+                {isRoutingActive && isPostLocation && userCoords && (
                   <View style={styles.locationRow}>
                     <Ionicons name="navigate" size={18} color={theme.colors.primary} />
                     <Text style={[styles.locationText, { color: theme.colors.text }]} numberOfLines={1}>

--- a/frontend/app/map/current-location.tsx
+++ b/frontend/app/map/current-location.tsx
@@ -527,13 +527,15 @@ export default function CurrentLocationMap() {
   };
 
   useEffect(() => {
-    if (route?.coordinates && route.coordinates.length > 0 && mapRef.current) {
-      mapRef.current.fitToCoordinates(route.coordinates, {
-        edgePadding: { top: 120, right: 50, bottom: 50, left: 50 },
-        animated: true,
-      });
+    if (route?.coordinates && route.coordinates.length > 0 && mapRef.current && !useWebViewFallback) {
+      if (typeof mapRef.current.fitToCoordinates === 'function') {
+        mapRef.current.fitToCoordinates(route.coordinates, {
+          edgePadding: { top: 120, right: 50, bottom: 50, left: 50 },
+          animated: true,
+        });
+      }
     }
-  }, [route]);
+  }, [route, useWebViewFallback]);
 
   const renderMap = () => {
     if (loading) {
@@ -632,6 +634,10 @@ html,body,#map{height:100%;margin:0;padding:0}
 .marker-thumb-placeholder {
   width: 26px;
   height: 26px;
+  min-width: 26px;
+  min-height: 26px;
+  flex-shrink: 0;
+  -webkit-flex-shrink: 0;
   border-radius: 50%;
   background: ${isDark ? 'rgba(45, 212, 191, 0.15)' : 'rgba(59, 130, 246, 0.1)'};
   display: flex;

--- a/frontend/app/navigate/detail.tsx
+++ b/frontend/app/navigate/detail.tsx
@@ -515,7 +515,13 @@ function initMap(){
                   <TouchableOpacity
                     key={`post-${index}`}
                     style={[styles.postCard, { backgroundColor: theme.colors.surface, borderColor: theme.colors.border }]}
-                    onPress={() => router.push(`/post/${post._id}`)}
+                    onPress={() => {
+                      if (waypoint.contentType === 'video' || waypoint.contentType === 'short' || post.type === 'short') {
+                        router.push(`/user-shorts/${journey.user}?shortId=${post._id}`);
+                      } else {
+                        router.push(`/post/${post._id}`);
+                      }
+                    }}
                     activeOpacity={0.7}
                   >
                     {imageUrl && (

--- a/frontend/app/saved-shorts/index.tsx
+++ b/frontend/app/saved-shorts/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Platform, Dimensions } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams, useRouter } from 'expo-router';
@@ -15,6 +15,7 @@ export default function SavedShortsScreen() {
   const { shortId } = useLocalSearchParams();
   const { theme } = useTheme();
   const router = useRouter();
+  const [isMuted, setIsMuted] = useState(false);
 
   const sid = typeof shortId === 'string' ? shortId : Array.isArray(shortId) ? shortId[0] : undefined;
 
@@ -48,6 +49,10 @@ export default function SavedShortsScreen() {
       color: '#ffffff',
       flex: 1,
     },
+    muteButton: {
+      padding: theme.spacing.xs,
+      marginLeft: theme.spacing.sm,
+    },
     shortsFlex: {
       flex: 1,
     },
@@ -68,9 +73,21 @@ export default function SavedShortsScreen() {
           <Text style={styles.headerTitle} numberOfLines={1}>
             Saved Shorts
           </Text>
+          <TouchableOpacity
+            style={styles.muteButton}
+            onPress={() => setIsMuted(prev => !prev)}
+            activeOpacity={0.7}
+          >
+            <Ionicons name={isMuted ? 'volume-mute' : 'volume-high'} size={24} color="#ffffff" />
+          </TouchableOpacity>
         </View>
         <View style={styles.shortsFlex}>
-          <Shorts isSavedShorts={true} initialShortId={sid} />
+          <Shorts 
+            isSavedShorts={true} 
+            initialShortId={sid} 
+            isMuted={isMuted}
+            onMuteToggle={() => setIsMuted(prev => !prev)}
+          />
         </View>
       </SafeAreaView>
     </ErrorBoundary>

--- a/frontend/app/tripscore/countries/[country]/locations/[location].tsx
+++ b/frontend/app/tripscore/countries/[country]/locations/[location].tsx
@@ -1311,9 +1311,9 @@ export default function LocationDetailScreen() {
             {/* Quick Info Cards */}
             <View style={styles.quickInfoContainer}>
               <BlurView
-                intensity={65}
+                intensity={95}
                 tint={isDark ? 'dark' : 'light'}
-                style={[styles.quickInfoCard, { overflow: 'hidden', backgroundColor: isDark ? 'rgba(10, 18, 32, 0.45)' : 'rgba(255, 255, 255, 0.45)', borderColor: theme.colors.border || 'rgba(0,0,0,0.08)' }]}
+                style={[styles.quickInfoCard, { overflow: 'hidden', backgroundColor: isDark ? 'rgba(15, 23, 42, 0.4)' : 'rgba(255, 255, 255, 0.4)', borderColor: isDark ? 'rgba(255, 255, 255, 0.15)' : 'rgba(255, 255, 255, 0.6)', borderWidth: 1 }]}
               >
                 <View style={styles.quickInfoHeader}>
                   <Ionicons name="navigate" size={18} color={theme.colors.primary} />
@@ -1340,9 +1340,9 @@ export default function LocationDetailScreen() {
               </BlurView>
 
               <BlurView
-                intensity={65}
+                intensity={95}
                 tint={isDark ? 'dark' : 'light'}
-                style={[styles.quickInfoCard, { overflow: 'hidden', backgroundColor: isDark ? 'rgba(10, 18, 32, 0.45)' : 'rgba(255, 255, 255, 0.45)', borderColor: theme.colors.border || 'rgba(0,0,0,0.08)' }]}
+                style={[styles.quickInfoCard, { overflow: 'hidden', backgroundColor: isDark ? 'rgba(15, 23, 42, 0.4)' : 'rgba(255, 255, 255, 0.4)', borderColor: isDark ? 'rgba(255, 255, 255, 0.15)' : 'rgba(255, 255, 255, 0.6)', borderWidth: 1 }]}
               >
                 <View style={styles.quickInfoHeader}>
                   <Ionicons name="leaf" size={18} color="#4CAF50" />
@@ -1362,9 +1362,9 @@ export default function LocationDetailScreen() {
             <View style={styles.quickInfoContainer}>
                 {/* Left Box - Travel Info */}
                 <BlurView
-                  intensity={65}
+                  intensity={95}
                   tint={isDark ? 'dark' : 'light'}
-                  style={[styles.quickInfoCard, { overflow: 'hidden', backgroundColor: isDark ? 'rgba(10, 18, 32, 0.45)' : 'rgba(255, 255, 255, 0.45)', borderColor: theme.colors.border || 'rgba(0,0,0,0.08)' }]}
+                  style={[styles.quickInfoCard, { flex: 2, overflow: 'hidden', backgroundColor: isDark ? 'rgba(15, 23, 42, 0.4)' : 'rgba(255, 255, 255, 0.4)', borderColor: isDark ? 'rgba(255, 255, 255, 0.15)' : 'rgba(255, 255, 255, 0.6)', borderWidth: 1 }]}
                 >
                   <View style={styles.quickInfoHeader}>
                     <Ionicons name="car" size={18} color={theme.colors.primary} />
@@ -1381,7 +1381,7 @@ export default function LocationDetailScreen() {
 
                 {/* Right Box - Explore on Map */}
                 <TouchableOpacity
-                  style={[styles.quickInfoCard, styles.clickableCard, { overflow: 'hidden', padding: 0, borderWidth: 0, backgroundColor: 'transparent' }]}
+                  style={[styles.quickInfoCard, styles.clickableCard, { flex: 3, overflow: 'hidden', padding: 0, borderWidth: 0, backgroundColor: 'transparent' }]}
                   activeOpacity={0.7}
                   disabled={navigatingToMap}
                   onPress={async () => {
@@ -1584,25 +1584,37 @@ export default function LocationDetailScreen() {
                   }}
                 >
                   <BlurView
-                    intensity={65}
+                    intensity={95}
                     tint={isDark ? 'dark' : 'light'}
-                    style={{ flex: 1, padding: 16, width: '100%', height: '100%', justifyContent: 'space-between', borderWidth: StyleSheet.hairlineWidth, borderColor: theme.colors.border || 'rgba(0,0,0,0.08)', borderRadius: 16, overflow: 'hidden', backgroundColor: isDark ? 'rgba(10, 18, 32, 0.45)' : 'rgba(255, 255, 255, 0.45)' }}
+                    style={{ flex: 1, padding: 16, width: '100%', height: '100%', justifyContent: 'space-between', borderWidth: 1, borderColor: isDark ? 'rgba(255, 255, 255, 0.15)' : 'rgba(255, 255, 255, 0.6)', borderRadius: 16, overflow: 'hidden', backgroundColor: isDark ? 'rgba(15, 23, 42, 0.4)' : 'rgba(255, 255, 255, 0.4)' }}
                   >
                     <View style={styles.quickInfoHeader}>
                       <View style={styles.headerLeft}>
                         <Ionicons name="globe-outline" size={18} color="#4CAF50" />
                         <Text style={[styles.quickInfoTitle, { color: theme.colors.text }]}>Explore on Map</Text>
                       </View>
-                      <View style={styles.clickableIndicator}>
-                        {navigatingToMap ? (
-                          <LoadingGlobe size="small" color="#4CAF50" />
-                        ) : (
-                          <Ionicons name="chevron-forward" size={16} color="#4CAF50" />
-                        )}
-                      </View>
                     </View>
                     <Text style={[styles.quickInfoValue, { color: theme.colors.text }]}>{navigatingToMap ? 'Opening…' : 'Navigate'}</Text>
                     <Text style={[styles.quickInfoSubtext, { color: theme.colors.textSecondary }]}>View {data.name} location</Text>
+                    
+                    <View style={{
+                      position: 'absolute',
+                      bottom: 16,
+                      right: 16,
+                      backgroundColor: 'rgba(76, 175, 80, 0.1)',
+                      borderRadius: 16,
+                      padding: 5,
+                      width: 28,
+                      height: 28,
+                      justifyContent: 'center',
+                      alignItems: 'center',
+                    }}>
+                      {navigatingToMap ? (
+                        <LoadingGlobe size="small" color="#4CAF50" />
+                      ) : (
+                        <Ionicons name="chevron-forward" size={16} color="#4CAF50" />
+                      )}
+                    </View>
                   </BlurView>
                 </TouchableOpacity>
               </View>

--- a/frontend/app/tripscore/countries/[country]/map.tsx
+++ b/frontend/app/tripscore/countries/[country]/map.tsx
@@ -498,6 +498,10 @@ export default function CountryMapScreen() {
           .marker-thumb {
             width: 26px;
             height: 26px;
+            min-width: 26px;
+            min-height: 26px;
+            flex-shrink: 0;
+            -webkit-flex-shrink: 0;
             border-radius: 50%;
             object-fit: cover;
             border: 1.5px solid ${isDark ? '#2DD4BF' : '#3B82F6'};
@@ -505,6 +509,10 @@ export default function CountryMapScreen() {
           .marker-thumb-placeholder {
             width: 26px;
             height: 26px;
+            min-width: 26px;
+            min-height: 26px;
+            flex-shrink: 0;
+            -webkit-flex-shrink: 0;
             border-radius: 50%;
             background: ${isDark ? 'rgba(45, 212, 191, 0.15)' : 'rgba(59, 130, 246, 0.1)'};
             display: flex;

--- a/frontend/app/tripscore/countries/[country]/map.tsx
+++ b/frontend/app/tripscore/countries/[country]/map.tsx
@@ -936,7 +936,7 @@ const styles = StyleSheet.create({
   previewImage: {
     width: 72,
     height: 72,
-    borderRadius: 16,
+    borderRadius: 36,
     overflow: 'hidden',
   },
   previewFallback: {

--- a/frontend/app/user-shorts/[userId].tsx
+++ b/frontend/app/user-shorts/[userId].tsx
@@ -27,6 +27,7 @@ export default function UserShortsScreen() {
   const { theme } = useTheme();
   const router = useRouter();
   const [user, setUser] = useState<{ fullName?: string } | null>(null);
+  const [isMuted, setIsMuted] = useState(false);
 
   const uid = normalizeParam(userId as string | string[] | undefined);
   const sid = normalizeParam(shortId as string | string[] | undefined);
@@ -75,6 +76,10 @@ export default function UserShortsScreen() {
       color: '#ffffff',
       flex: 1,
     },
+    muteButton: {
+      padding: theme.spacing.xs,
+      marginLeft: theme.spacing.sm,
+    },
     shortsFlex: {
       flex: 1,
     },
@@ -119,9 +124,21 @@ export default function UserShortsScreen() {
           <Text style={styles.headerTitle} numberOfLines={1}>
             {user?.fullName ? `${user.fullName}'s Shorts` : 'Shorts'}
           </Text>
+          <TouchableOpacity
+            style={styles.muteButton}
+            onPress={() => setIsMuted(prev => !prev)}
+            activeOpacity={0.7}
+          >
+            <Ionicons name={isMuted ? 'volume-mute' : 'volume-high'} size={24} color="#ffffff" />
+          </TouchableOpacity>
         </View>
         <View style={styles.shortsFlex}>
-          <Shorts scopedUserId={uid} initialShortId={sid} />
+          <Shorts 
+            scopedUserId={uid} 
+            initialShortId={sid} 
+            isMuted={isMuted} 
+            onMuteToggle={() => setIsMuted(prev => !prev)} 
+          />
         </View>
       </SafeAreaView>
     </ErrorBoundary>

--- a/frontend/components/ProgressAlert.tsx
+++ b/frontend/components/ProgressAlert.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../context/ThemeContext';
+import { LinearGradient } from 'expo-linear-gradient';
 
 export interface ProgressAlertProps {
   visible: boolean;
@@ -153,15 +154,22 @@ const ProgressAlert: React.FC<ProgressAlertProps> = ({
                 style={[
                   styles.progressBar,
                   {
-                    backgroundColor: color,
                     width: progressAnim.interpolate({
                       inputRange: [0, 100],
                       outputRange: ['0%', '100%'],
                       extrapolate: 'clamp',
                     }),
+                    overflow: 'hidden',
                   },
                 ]}
-              />
+              >
+                <LinearGradient
+                  colors={theme.colors.gradient?.secondary || ['#1C73B4', '#50C878']}
+                  start={{ x: 0, y: 0 }}
+                  end={{ x: 1, y: 0 }}
+                  style={StyleSheet.absoluteFillObject}
+                />
+              </Animated.View>
             </View>
           </View>
 

--- a/frontend/components/SongPlayer.tsx
+++ b/frontend/components/SongPlayer.tsx
@@ -23,7 +23,7 @@ interface SongPlayerProps {
 /**
  * Cache remote audio files locally to eliminate network buffering latency on seeks & loops.
  */
-const cacheSongLocally = async (remoteUrl: string): Promise<string> => {
+const cacheSongLocally = async (remoteUrl: string, forceRefresh: boolean = false): Promise<string> => {
   try {
     const cleanUrl = remoteUrl.trim();
     if (!cleanUrl.startsWith('http://') && !cleanUrl.startsWith('https://')) {
@@ -37,11 +37,26 @@ const cacheSongLocally = async (remoteUrl: string): Promise<string> => {
 
     const localPath = `${cacheDir}songs/${filename}`;
 
+    // If forceRefresh is requested, delete any existing file first
+    if (forceRefresh) {
+      try {
+        const info = await FileSystem.getInfoAsync(localPath);
+        if (info.exists) {
+          await FileSystem.deleteAsync(localPath, { idempotent: true });
+          logger.debug(`[AudioCache] Force refreshed: deleted existing cache for ${filename}`);
+        }
+      } catch (err) {
+        logger.warn(`[AudioCache] Failed to delete existing cache for ${filename}:`, err);
+      }
+    }
+
     // Check if the file is already cached and valid
-    const info = await FileSystem.getInfoAsync(localPath);
-    if (info.exists && info.size && info.size > 0) {
-      logger.debug(`[AudioCache] Cache hit: ${filename}`);
-      return localPath;
+    if (!forceRefresh) {
+      const info = await FileSystem.getInfoAsync(localPath);
+      if (info.exists && info.size && info.size > 0) {
+        logger.debug(`[AudioCache] Cache hit: ${filename}`);
+        return localPath;
+      }
     }
 
     // Ensure directory exists
@@ -54,6 +69,13 @@ const cacheSongLocally = async (remoteUrl: string): Promise<string> => {
     
     if (downloadResult.status === 200) {
       return localPath;
+    }
+    
+    // Clean up bad download (e.g. 403 XML page) so it doesn't corrupt subsequent cache hits
+    try {
+      await FileSystem.deleteAsync(localPath, { idempotent: true });
+    } catch (err) {
+      logger.warn(`[AudioCache] Failed to clean up bad download file for ${filename}:`, err);
     }
     return cleanUrl;
   } catch (error) {
@@ -240,8 +262,9 @@ function SongPlayerComponent({ post, isVisible = true, autoPlay = false, showPla
 
       setIsLoading(true);
       
-      // Cache song locally first to eliminate network buffering latency on seeks & loops
-      const localUri = await cacheSongLocally(audioUrlRaw);
+      // Cache song locally first to eliminate network buffering latency on seeks & loops.
+      // If we are retrying, forceRefresh the cache.
+      const localUri = await cacheSongLocally(audioUrlRaw, retryCount > 0);
 
       if (isStale()) {
         setIsLoading(false);
@@ -411,21 +434,20 @@ function SongPlayerComponent({ post, isVisible = true, autoPlay = false, showPla
         return; // Don't throw error or log to Sentry
       }
       
-      // Handle signed URL expiry - retry once with fresh URL
-      const isTimeout = errorMessage.includes('timeout') || errorMessage.includes('60');
-      const is403 = errorMessage.includes('403') || errorMessage.includes('Forbidden');
-      const isExpired = errorMessage.includes('expired') || errorMessage.includes('ExpiredRequest');
-      
-      if ((isTimeout || is403 || isExpired) && retryCount === 0) {
-        logger.debug('🔄 URL may be expired, fetching fresh URL and retrying...');
+      // Handle signed URL expiry - retry once with fresh URL for any non-cancellation errors.
+      // On Android, ExoPlayer errors (e.g. "v8.x$b" or "None of the available extractors could read the stream")
+      // are thrown instead of clean 403 Forbidden errors when presigned URLs expire.
+      if (retryCount === 0) {
+        logger.info('🔄 Playback error occurred (first attempt). Fetching fresh URL and retrying...');
         const freshUrl = await fetchFreshSignedUrl();
         if (freshUrl) {
-          // Update song object with fresh URL
+          // Update song object with fresh URL in-memory
           if (song) {
             (song as any).s3Url = freshUrl;
             (song as any).cloudinaryUrl = freshUrl;
           }
-          // Retry once with fresh URL
+          setFetchedUrl(freshUrl);
+          // Retry once with fresh URL, which will trigger forceRefresh on cache Song
           return loadAndPlaySong(forcePlay, 1);
         }
       }

--- a/frontend/components/TravelLoadingOverlay.tsx
+++ b/frontend/components/TravelLoadingOverlay.tsx
@@ -1,19 +1,9 @@
 import React, { useEffect, useRef } from 'react';
-import { View, Text, Animated, Easing, StyleSheet, Dimensions, Platform } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
+import { View, Animated, Easing, StyleSheet, Dimensions, Platform } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import LoadingGlobe from './LoadingGlobe';
 
 const { width: screenWidth } = Dimensions.get('window');
-const isTabletLocal = screenWidth >= 768;
-
-const isWeb = Platform.OS === 'web';
-const isIOS = Platform.OS === 'ios';
-const getFontFamily = (weight: '400' | '500' | '600' | '700' | '800' = '400') => {
-  if (isWeb) return 'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
-  if (isIOS) return 'System';
-  return 'Roboto';
-};
 
 interface TravelLoadingOverlayProps {
   /** When true the overlay is mounted, animations spin up. Toggling false fades it out. */
@@ -24,72 +14,21 @@ interface TravelLoadingOverlayProps {
   theme: { colors: { primary: string; text: string; textSecondary: string } };
 }
 
-/**
- * Module-scope component (was previously declared inline inside LocaleScreen).
- * Defining it inline made every parent re-render unmount and remount the
- * overlay, restarting all 9 animation loops and producing the rare native-
- * animation-after-free crash that motivated the original cleanup pass.
- * Lifting it here gives it a stable identity across renders, so the
- * animation lifecycle is governed purely by `calculatingDistances`.
- */
 const TravelLoadingOverlay: React.FC<TravelLoadingOverlayProps> = ({
   calculatingDistances,
   mode,
   theme,
 }) => {
-  const rotateAnim = useRef(new Animated.Value(0)).current;
-  const pulseAnim = useRef(new Animated.Value(0)).current;
   const fadeAnim = useRef(new Animated.Value(0)).current;
-  const floatAnim = useRef(new Animated.Value(0)).current;
-  const globeRotateAnim = useRef(new Animated.Value(0)).current;
-  const shimmerAnim = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
     if (calculatingDistances) {
-      Animated.parallel([
-        Animated.timing(fadeAnim, {
-          toValue: 1,
-          duration: 400,
-          easing: Easing.out(Easing.cubic),
-          useNativeDriver: true,
-        }),
-        Animated.loop(
-          Animated.timing(rotateAnim, {
-            toValue: 1,
-            duration: 4000,
-            easing: Easing.linear,
-            useNativeDriver: true,
-          })
-        ),
-        Animated.loop(
-          Animated.sequence([
-            Animated.timing(pulseAnim, { toValue: 1, duration: 1500, easing: Easing.inOut(Easing.ease), useNativeDriver: true }),
-            Animated.timing(pulseAnim, { toValue: 0, duration: 1500, easing: Easing.inOut(Easing.ease), useNativeDriver: true }),
-          ])
-        ),
-        Animated.loop(
-          Animated.sequence([
-            Animated.timing(floatAnim, { toValue: 1, duration: 2000, easing: Easing.inOut(Easing.ease), useNativeDriver: true }),
-            Animated.timing(floatAnim, { toValue: 0, duration: 2000, easing: Easing.inOut(Easing.ease), useNativeDriver: true }),
-          ])
-        ),
-        Animated.loop(
-          Animated.timing(globeRotateAnim, {
-            toValue: 1,
-            duration: 8000,
-            easing: Easing.linear,
-            useNativeDriver: true,
-          })
-        ),
-        Animated.loop(
-          Animated.timing(shimmerAnim, {
-            toValue: 1,
-            duration: 2000,
-            easing: Easing.linear,
-            useNativeDriver: true,
-          })
-        ),
-      ]).start();
+      Animated.timing(fadeAnim, {
+        toValue: 1,
+        duration: 400,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }).start();
     } else {
       Animated.timing(fadeAnim, {
         toValue: 0,
@@ -99,21 +38,9 @@ const TravelLoadingOverlay: React.FC<TravelLoadingOverlayProps> = ({
     }
 
     return () => {
-      rotateAnim.stopAnimation();
-      pulseAnim.stopAnimation();
       fadeAnim.stopAnimation();
-      floatAnim.stopAnimation();
-      globeRotateAnim.stopAnimation();
-      shimmerAnim.stopAnimation();
     };
-  }, [calculatingDistances, rotateAnim, pulseAnim, fadeAnim, floatAnim, globeRotateAnim, shimmerAnim]);
-
-  const rotation = rotateAnim.interpolate({ inputRange: [0, 1], outputRange: ['0deg', '360deg'] });
-  const scale = pulseAnim.interpolate({ inputRange: [0, 1], outputRange: [1, 1.15] });
-  const translateY = floatAnim.interpolate({ inputRange: [0, 1], outputRange: [0, -15] });
-  const globeRotation = globeRotateAnim.interpolate({ inputRange: [0, 1], outputRange: ['0deg', '360deg'] });
-  const shimmerTranslate = shimmerAnim.interpolate({ inputRange: [0, 1], outputRange: [-100, 100] });
-  const shimmerOpacity = shimmerAnim.interpolate({ inputRange: [0, 0.5, 1], outputRange: [0, 0.3, 0] });
+  }, [calculatingDistances, fadeAnim]);
 
   if (!calculatingDistances) return null;
 
@@ -135,54 +62,13 @@ const TravelLoadingOverlay: React.FC<TravelLoadingOverlayProps> = ({
         style={styles.travelLoadingGradient}
       >
         <View style={styles.travelLoadingContent}>
-          <Animated.View
-            style={[
-              styles.travelIconContainer,
-              { transform: [{ rotate: rotation }, { scale }, { translateY }] },
-            ]}
-          >
-            <Animated.View
-              style={[
-                styles.travelGlobeBackground,
-                { transform: [{ rotate: globeRotation }], opacity: 0.12 },
-              ]}
-              pointerEvents="none"
-            >
-              <Ionicons name="earth" size={100} color={theme.colors.primary} />
-            </Animated.View>
-
-            <View style={styles.travelIconWrapper}>
-              <Animated.View
-                style={[
-                  styles.travelShimmer,
-                  { transform: [{ translateX: shimmerTranslate }], opacity: shimmerOpacity },
-                ]}
-                pointerEvents="none"
-              />
-              <Ionicons name="airplane" size={56} color={theme.colors.primary} style={styles.travelAirplaneIcon} />
-            </View>
-          </Animated.View>
-
-          <View style={styles.travelDotsContainer}>
-            <LoadingGlobe size="small" color={theme.colors.primary} />
-          </View>
-
-          <View style={styles.travelTextContainer}>
-            <Text style={[styles.travelLoadingText, { color: theme.colors.text }]}>
-              Capturing the best locales for you
-            </Text>
-            <Text style={[styles.travelLoadingSubtext, { color: theme.colors.textSecondary }]}>
-              Calculating distances...
-            </Text>
-          </View>
+          <LoadingGlobe size={54} color={theme.colors.primary} />
         </View>
       </LinearGradient>
     </Animated.View>
   );
 };
 
-// Styles cloned verbatim from the original locale.tsx StyleSheet so the
-// extracted component renders identically.
 const styles = StyleSheet.create({
   travelLoadingOverlay: {
     position: 'absolute',
@@ -204,90 +90,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     padding: 40,
-    borderRadius: 32,
     backgroundColor: 'transparent',
-    minWidth: 300,
-    maxWidth: 340,
-    overflow: 'hidden',
-    position: 'relative',
-  },
-  travelIconContainer: {
-    marginBottom: 32,
-    alignItems: 'center',
-    justifyContent: 'center',
-    zIndex: 2,
-    position: 'relative',
-    width: 140,
-    height: 140,
-  },
-  travelGlobeBackground: {
-    position: 'absolute',
-    top: '50%',
-    left: '50%',
-    marginTop: -50,
-    marginLeft: -50,
-    zIndex: 0,
-    width: 100,
-    height: 100,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  travelIconWrapper: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    backgroundColor: 'rgba(74, 144, 226, 0.1)',
-    borderWidth: 2,
-    borderColor: 'rgba(74, 144, 226, 0.2)',
-    zIndex: 2,
-    position: 'relative',
-    overflow: 'hidden',
-  },
-  travelShimmer: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    width: 80,
-    height: 80,
-    backgroundColor: 'rgba(255, 255, 255, 0.4)',
-    borderRadius: 40,
-    zIndex: 1,
-  },
-  travelAirplaneIcon: {
-    zIndex: 3,
-    position: 'relative',
-  },
-  travelDotsContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: 24,
-    gap: 12,
-    zIndex: 2,
-  },
-
-  travelTextContainer: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    zIndex: 2,
-  },
-  travelLoadingText: {
-    fontSize: 17,
-    fontFamily: getFontFamily('600'),
-    fontWeight: '600',
-    textAlign: 'center',
-    marginBottom: 6,
-    letterSpacing: 0.1,
-  },
-  travelLoadingSubtext: {
-    fontSize: 14,
-    fontFamily: getFontFamily('400'),
-    fontWeight: '400',
-    textAlign: 'center',
-    opacity: 0.7,
-    letterSpacing: 0.1,
   },
 });
 

--- a/frontend/components/chat/ChatMediaViewer.tsx
+++ b/frontend/components/chat/ChatMediaViewer.tsx
@@ -129,7 +129,10 @@ export default function ChatMediaViewer({
   // Gestures definition
   const pinchGesture = Gesture.Pinch()
     .onUpdate((event) => {
-      scale.value = Math.min(3, Math.max(1, savedScale.value * event.scale));
+      // Only process updates if exactly 2 fingers are touching to prevent focal point jumps on iOS
+      if (event.numberOfPointers === 2) {
+        scale.value = Math.min(3, Math.max(1, savedScale.value * event.scale));
+      }
     })
     .onEnd(() => {
       savedScale.value = scale.value;

--- a/frontend/components/post/AspectImageCropper.tsx
+++ b/frontend/components/post/AspectImageCropper.tsx
@@ -121,11 +121,14 @@ export default function AspectImageCropper({
 
   const pinchGesture = Gesture.Pinch()
     .onUpdate((e) => {
-      const next = Math.min(4, Math.max(1, savedScale.value * e.scale));
-      scale.value = next;
-      const { maxX, maxY } = clampPan(next);
-      tx.value = Math.max(-maxX, Math.min(maxX, tx.value));
-      ty.value = Math.max(-maxY, Math.min(maxY, ty.value));
+      // Only process updates if exactly 2 fingers are touching to prevent focal point jumps on iOS
+      if (e.numberOfPointers === 2) {
+        const next = Math.min(4, Math.max(1, savedScale.value * e.scale));
+        scale.value = next;
+        const { maxX, maxY } = clampPan(next);
+        tx.value = Math.max(-maxX, Math.min(maxX, tx.value));
+        ty.value = Math.max(-maxY, Math.min(maxY, ty.value));
+      }
     })
     .onEnd(() => {
       savedScale.value = scale.value;

--- a/frontend/components/post/PostImage.tsx
+++ b/frontend/components/post/PostImage.tsx
@@ -396,11 +396,14 @@ export default function PostImage({
       }
     })
     .onUpdate((e) => {
-      // Clamp scale within the UI worklet to prevent crashes (Max 5, Min 1)
-      const currentScale = (e.scale && !isNaN(e.scale) && isFinite(e.scale)) ? e.scale : 1;
-      scale.value = Math.max(1, Math.min(currentScale, 5));
-      focalX.value = (e.focalX && !isNaN(e.focalX) && isFinite(e.focalX)) ? e.focalX : 0;
-      focalY.value = (e.focalY && !isNaN(e.focalY) && isFinite(e.focalY)) ? e.focalY : 0;
+      // Only process pinch updates if 2 fingers are touching to prevent focal jumps on iOS
+      if (e.numberOfPointers === 2) {
+        // Clamp scale within the UI worklet to prevent crashes (Max 5, Min 1)
+        const currentScale = (e.scale && !isNaN(e.scale) && isFinite(e.scale)) ? e.scale : 1;
+        scale.value = Math.max(1, Math.min(currentScale, 5));
+        focalX.value = (e.focalX && !isNaN(e.focalX) && isFinite(e.focalX)) ? e.focalX : 0;
+        focalY.value = (e.focalY && !isNaN(e.focalY) && isFinite(e.focalY)) ? e.focalY : 0;
+      }
     })
     .onEnd(() => {
       // Automatic snap-back feature (BUG-002) using withSpring for smooth reset

--- a/frontend/constants/admob.js
+++ b/frontend/constants/admob.js
@@ -26,7 +26,7 @@ export const ADMOB = {
   android: {
     banner: __DEV__
       ? 'ca-app-pub-3940256099942544/6300978111'
-      : 'ca-app-pub-6362359854606661/XXXXXXXXXX',
+      : 'ca-app-pub-6362359854606661/7027944948',
     interstitial: __DEV__
       ? 'ca-app-pub-3940256099942544/1033173712'
       : 'ca-app-pub-6362359854606661/XXXXXXXXXX',
@@ -43,7 +43,7 @@ export const ADMOB = {
   ios: {
     banner: __DEV__
       ? 'ca-app-pub-3940256099942544/2934735716'
-      : 'ca-app-pub-6362359854606661/XXXXXXXXXX',
+      : 'ca-app-pub-6362359854606661/2303221559',
     interstitial: __DEV__
       ? 'ca-app-pub-3940256099942544/4411468910'
       : 'ca-app-pub-6362359854606661/XXXXXXXXXX',

--- a/frontend/constants/admob.js
+++ b/frontend/constants/admob.js
@@ -26,14 +26,14 @@ export const ADMOB = {
   android: {
     banner: __DEV__
       ? 'ca-app-pub-3940256099942544/6300978111'
-      : 'ca-app-pub-6362359854686661/XXXXXXXXXX',
+      : 'ca-app-pub-6362359854606661/XXXXXXXXXX',
     interstitial: __DEV__
       ? 'ca-app-pub-3940256099942544/1033173712'
-      : 'ca-app-pub-6362359854686661/XXXXXXXXXX',
-    /** Native Advanced (in-feed) ad unit. Production: ca-app-pub-6362359854686661/2564972909 */
+      : 'ca-app-pub-6362359854606661/XXXXXXXXXX',
+    /** Native Advanced (in-feed) ad unit. Production: ca-app-pub-6362359854606661/2564972909 */
     native: __DEV__
       ? 'ca-app-pub-3940256099942544/2247696110'
-      : 'ca-app-pub-6362359854686661/2564972909',
+      : 'ca-app-pub-6362359854606661/2564972909',
   },
 
   /**

--- a/frontend/context/AlertContext.tsx
+++ b/frontend/context/AlertContext.tsx
@@ -87,7 +87,7 @@ export const AlertProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     setAlertState(prev => ({ ...prev, visible: false }));
   };
 
-  const showOptions = (config: Partial<OptionsState>) => {
+  const triggerShowOptions = (config: Partial<OptionsState>) => {
     setOptionsState({
       visible: true,
       options: [],
@@ -204,7 +204,7 @@ export const AlertProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       showCancel?: boolean,
       cancelText?: string
     ) => {
-      showOptions({
+      triggerShowOptions({
         title,
         message,
         options,

--- a/frontend/context/SettingsContext.tsx
+++ b/frontend/context/SettingsContext.tsx
@@ -210,9 +210,21 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children }) 
   const updateAllSettings = useCallback(async (newSettings: Partial<UserSettings>) => {
     if (!settings) return;
     
-    // Optimistic update
+    // Optimistic update with deep merge for top-level categories
     const previousSettings = settings;
-    setSettings({ ...settings, ...newSettings } as UserSettings);
+    
+    const mergedSettings = { ...settings };
+    Object.keys(newSettings).forEach(key => {
+      const category = key as keyof UserSettings;
+      if (newSettings[category] && typeof newSettings[category] === 'object') {
+        mergedSettings[category] = {
+          ...mergedSettings[category],
+          ...newSettings[category]
+        } as any;
+      }
+    });
+    
+    setSettings(mergedSettings);
     
     try {
       const response = await updateSettings(newSettings);

--- a/frontend/hooks/useJourneyTracking.ts
+++ b/frontend/hooks/useJourneyTracking.ts
@@ -23,6 +23,7 @@ import {
 } from '../services/journey';
 import { Journey, Coordinate } from '../types/journey';
 import { calculateCoordinateDistance } from '../components/PolylineRenderer';
+import { KalmanFilter } from '../utils/kalmanFilter';
 
 // Simple logger fallback (uses console if no logger util exists)
 const logger = {
@@ -247,6 +248,7 @@ export function useJourneyTracking(): UseJourneyTrackingReturn {
   const appStateRef = useRef(AppState.currentState);
   const startTimeRef = useRef<number | null>(null);
   const pendingSegmentBreakRef = useRef(false);
+  const kalmanFilterRef = useRef<KalmanFilter | null>(null);
   // Tracks whether this hook instance is still mounted. Async paths (API
   // awaits, location callbacks fired after subscription removal on some
   // Android OEMs, late timer ticks) check this before calling setState so
@@ -311,9 +313,15 @@ export function useJourneyTracking(): UseJourneyTrackingReturn {
           return;
         }
 
+        // Apply Kalman Filter smoothing
+        if (!kalmanFilterRef.current) {
+          kalmanFilterRef.current = new KalmanFilter(lat, lng, accuracy, location.timestamp);
+        }
+        const smoothed = kalmanFilterRef.current.update(lat, lng, accuracy, location.timestamp);
+
         const coord: Coordinate = {
-          latitude: lat,
-          longitude: lng,
+          latitude: smoothed.latitude,
+          longitude: smoothed.longitude,
           timestamp: location.timestamp,
           accuracy,
         };
@@ -574,6 +582,7 @@ export function useJourneyTracking(): UseJourneyTrackingReturn {
           startTimeRef.current = null;
           lastCoordinateRef.current = null;
           pendingSegmentBreakRef.current = false;
+          kalmanFilterRef.current = null;
           batchCoordinatesRef.current = [];
           setIsTracking(false);
           setIsPaused(false);
@@ -789,6 +798,21 @@ export function useJourneyTracking(): UseJourneyTrackingReturn {
         !isDuplicateTimestamp(c.timestamp)
       );
 
+      // Smooth background coordinate batch sequentially
+      const smoothedCoords = valid.map((c) => {
+        const acc = c.accuracy || 10;
+        const ts = typeof c.timestamp === 'number' ? c.timestamp : Date.now();
+        if (!kalmanFilterRef.current) {
+          kalmanFilterRef.current = new KalmanFilter(c.latitude, c.longitude, acc, ts);
+        }
+        const smoothed = kalmanFilterRef.current.update(c.latitude, c.longitude, acc, ts);
+        return {
+          ...c,
+          latitude: smoothed.latitude,
+          longitude: smoothed.longitude,
+        };
+      });
+
       // Apply the same MIN_LOCATION_DISTANCE filter the foreground watcher
       // uses, walking from the last known polyline tail forward, so a row
       // of background coords doesn't introduce a denser-than-foreground
@@ -796,7 +820,7 @@ export function useJourneyTracking(): UseJourneyTrackingReturn {
       let lastCoord = lastCoordinateRef.current;
       const accepted: Coordinate[] = [];
       let addedDistance = 0;
-      for (const c of valid) {
+      for (const c of smoothedCoords) {
         if (!lastCoord) {
           accepted.push(c);
           lastCoord = c;
@@ -945,6 +969,12 @@ export function useJourneyTracking(): UseJourneyTrackingReturn {
           timestamp: Date.now(),
           accuracy: location.coords.accuracy || 0,
         };
+        kalmanFilterRef.current = new KalmanFilter(
+          initialCoord.latitude,
+          initialCoord.longitude,
+          initialCoord.accuracy,
+          initialCoord.timestamp
+        );
         lastCoordinateRef.current = initialCoord;
         pendingSegmentBreakRef.current = false;
         setPolyline([initialCoord]);
@@ -1065,6 +1095,7 @@ export function useJourneyTracking(): UseJourneyTrackingReturn {
       setDuration(resumedDuration);
       lastCoordinateRef.current = null; // Clear to guarantee first location fix starts a new segment
       pendingSegmentBreakRef.current = true;
+      kalmanFilterRef.current = null; // Reset Kalman Filter on resume to avoid velocity projection jump from pause gap
 
       // Restart location watcher via the centralized helper.
       await startLocationWatcher();
@@ -1245,6 +1276,7 @@ export function useJourneyTracking(): UseJourneyTrackingReturn {
       startTimeRef.current = null;
       lastCoordinateRef.current = null;
       pendingSegmentBreakRef.current = false;
+      kalmanFilterRef.current = null;
       batchCoordinatesRef.current = [];
       setIsTracking(false);
       setIsPaused(false);

--- a/frontend/src/utils/uploadShort.ts
+++ b/frontend/src/utils/uploadShort.ts
@@ -1,4 +1,4 @@
-import * as FileSystem from 'expo-file-system';
+import * as FileSystem from 'expo-file-system/legacy';
 import { createLogger } from '../../utils/logger';
 
 const logger = createLogger('UploadShort');

--- a/frontend/src/utils/videoCache.ts
+++ b/frontend/src/utils/videoCache.ts
@@ -1,10 +1,13 @@
-import * as FileSystem from 'expo-file-system';
+import * as FileSystem from 'expo-file-system/legacy';
 import { createLogger } from '../../utils/logger';
 
 const logger = createLogger('VideoCache');
 
 const MAX_CACHED_VIDEOS = 8;
 const cacheQueue: string[] = []; // ordered oldest → newest
+
+// Deduplicate active downloads to prevent concurrent requests for the same video
+const activeDownloads = new Map<string, Promise<string>>();
 
 /**
  * Get the cache directory path
@@ -40,84 +43,126 @@ async function validateCachedFile(localPath: string): Promise<boolean> {
   }
 }
 
-export async function cacheVideoLocally(remoteUrl: string): Promise<string> {
+/**
+ * Retrieve the validated local URI for a cached video if it exists.
+ * Returns null if the video is not cached or invalid.
+ */
+export async function getLocalVideoUri(videoId: string): Promise<string | null> {
   try {
-    const filename = remoteUrl.split('/').pop() ?? `vid_${Date.now()}.mp4`;
     const cacheDir = getCachePath();
-    const localPath = `${cacheDir}shorts/${filename}`;
+    const mp4Path = `${cacheDir}shorts/${videoId}.mp4`;
+    const m3u8Path = `${cacheDir}shorts/${videoId}.m3u8`;
 
-    logger.info(`[VideoCache] cacheVideoLocally called for: ${filename}`, {
-      remoteUrl: remoteUrl.substring(0, 100),
-      localPath,
-      timestamp: new Date().toISOString()
-    });
-
-    // Check if already cached
-    const info = await FileSystem.getInfoAsync(localPath);
-    if (info.exists) {
-      // Validate cached file before using it
-      const isValid = await validateCachedFile(localPath);
-      if (isValid) {
-        // Move to end of queue (recently used)
-        const idx = cacheQueue.indexOf(localPath);
-        if (idx !== -1) {
-          cacheQueue.splice(idx, 1);
-        }
-        cacheQueue.push(localPath);
-        logger.debug(`[VideoCache] Cache hit: ${filename}`);
-        logger.info(`[VideoCache] CACHE_HIT for ${filename}, queue: ${cacheQueue.length}/${MAX_CACHED_VIDEOS}`);
-        return localPath;
-      } else {
-        // File is corrupted or invalid, remove from cache
-        logger.warn(`[VideoCache] Cache file invalid, removing: ${filename}`);
-        await removeCachedVideo(localPath);
-        // Fall through to re-download
-      }
-    } else {
-      logger.info(`[VideoCache] CACHE_MISS for ${filename}, will download`);
+    if (await validateCachedFile(mp4Path)) {
+      return mp4Path;
     }
-
-    // Ensure cache dir exists
-    await FileSystem.makeDirectoryAsync(
-      `${cacheDir}shorts/`,
-      { intermediates: true }
-    );
-
-    // Download video
-    logger.debug(`[VideoCache] Downloading: ${filename}`);
-    logger.info(`[VideoCache] DOWNLOAD_START for ${filename}`);
-    try {
-      await FileSystem.downloadAsync(remoteUrl, localPath);
-      cacheQueue.push(localPath);
-      logger.debug(`[VideoCache] Downloaded: ${filename} (queue: ${cacheQueue.length}/${MAX_CACHED_VIDEOS})`);
-      logger.info(`[VideoCache] DOWNLOAD_COMPLETE for ${filename}, queue: ${cacheQueue.length}/${MAX_CACHED_VIDEOS}`);
-    } catch (downloadError) {
-      logger.error(`[VideoCache] Download failed for ${filename}:`, downloadError);
-      logger.error(`[VideoCache] DOWNLOAD_FAILED for ${filename}`);
-      throw downloadError;
+    if (await validateCachedFile(m3u8Path)) {
+      return m3u8Path;
     }
-
-    // Evict oldest if over limit
-    while (cacheQueue.length > MAX_CACHED_VIDEOS) {
-      const evict = cacheQueue.shift();
-      if (evict) {
-        try {
-          const evictInfo = await FileSystem.getInfoAsync(evict);
-          if (evictInfo.exists) {
-            await FileSystem.deleteAsync(evict);
-            logger.debug(`[VideoCache] Evicted: ${evict.split('/').pop()}`);
-            logger.info(`[VideoCache] EVICTED: ${evict.split('/').pop()}`);
-          }
-        } catch (err) {
-          logger.warn(`[VideoCache] Failed to evict ${evict}:`, err);
-        }
-      }
-    }
-
-    return localPath;
+    return null;
   } catch (error) {
-    logger.error(`[VideoCache] Error caching video:`, error);
-    throw error;
+    logger.warn(`[VideoCache] Error checking local URI for ${videoId}:`, error);
+    return null;
+  }
+}
+
+export async function cacheVideoLocally(videoId: string, remoteUrl: string): Promise<string> {
+  // Return active download promise if already in progress to prevent duplicate fetching
+  const existingDownload = activeDownloads.get(videoId);
+  if (existingDownload) {
+    logger.debug(`[VideoCache] Re-using active download promise for video: ${videoId}`);
+    return existingDownload;
+  }
+
+  const downloadPromise = (async () => {
+    try {
+      const lowercaseUrl = remoteUrl.toLowerCase();
+      const ext = (lowercaseUrl.includes('m3u8') || lowercaseUrl.includes('hls')) ? 'm3u8' : 'mp4';
+      const filename = `${videoId}.${ext}`;
+      const cacheDir = getCachePath();
+      const localPath = `${cacheDir}shorts/${filename}`;
+
+      logger.info(`[VideoCache] cacheVideoLocally called for video ${videoId}: ${filename}`, {
+        remoteUrl: remoteUrl.substring(0, 100),
+        localPath,
+        timestamp: new Date().toISOString()
+      });
+
+      // Check if already cached
+      const info = await FileSystem.getInfoAsync(localPath);
+      if (info.exists) {
+        // Validate cached file before using it
+        const isValid = await validateCachedFile(localPath);
+        if (isValid) {
+          // Move to end of queue (recently used)
+          const idx = cacheQueue.indexOf(localPath);
+          if (idx !== -1) {
+            cacheQueue.splice(idx, 1);
+          }
+          cacheQueue.push(localPath);
+          logger.debug(`[VideoCache] Cache hit: ${filename}`);
+          logger.info(`[VideoCache] CACHE_HIT for ${filename}, queue: ${cacheQueue.length}/${MAX_CACHED_VIDEOS}`);
+          return localPath;
+        } else {
+          // File is corrupted or invalid, remove from cache
+          logger.warn(`[VideoCache] Cache file invalid, removing: ${filename}`);
+          await removeCachedVideo(localPath);
+          // Fall through to re-download
+        }
+      } else {
+        logger.info(`[VideoCache] CACHE_MISS for ${filename}, will download`);
+      }
+
+      // Ensure cache dir exists
+      await FileSystem.makeDirectoryAsync(
+        `${cacheDir}shorts/`,
+        { intermediates: true }
+      );
+
+      // Download video
+      logger.debug(`[VideoCache] Downloading: ${filename}`);
+      logger.info(`[VideoCache] DOWNLOAD_START for ${filename}`);
+      try {
+        await FileSystem.downloadAsync(remoteUrl, localPath);
+        cacheQueue.push(localPath);
+        logger.debug(`[VideoCache] Downloaded: ${filename} (queue: ${cacheQueue.length}/${MAX_CACHED_VIDEOS})`);
+        logger.info(`[VideoCache] DOWNLOAD_COMPLETE for ${filename}, queue: ${cacheQueue.length}/${MAX_CACHED_VIDEOS}`);
+      } catch (downloadError) {
+        logger.error(`[VideoCache] Download failed for ${filename}:`, downloadError);
+        logger.error(`[VideoCache] DOWNLOAD_FAILED for ${filename}`);
+        throw downloadError;
+      }
+
+      // Evict oldest if over limit
+      while (cacheQueue.length > MAX_CACHED_VIDEOS) {
+        const evict = cacheQueue.shift();
+        if (evict) {
+          try {
+            const evictInfo = await FileSystem.getInfoAsync(evict);
+            if (evictInfo.exists) {
+              await FileSystem.deleteAsync(evict);
+              logger.debug(`[VideoCache] Evicted: ${evict.split('/').pop()}`);
+              logger.info(`[VideoCache] EVICTED: ${evict.split('/').pop()}`);
+            }
+          } catch (err) {
+            logger.warn(`[VideoCache] Failed to evict ${evict}:`, err);
+          }
+        }
+      }
+
+      return localPath;
+    } catch (error) {
+      logger.error(`[VideoCache] Error caching video ${videoId}:`, error);
+      throw error;
+    }
+  })();
+
+  activeDownloads.set(videoId, downloadPromise);
+  
+  try {
+    return await downloadPromise;
+  } finally {
+    activeDownloads.delete(videoId);
   }
 }
 
@@ -130,6 +175,7 @@ export async function clearVideoCache(): Promise<void> {
       logger.debug(`[VideoCache] Cleared cache directory`);
     }
     cacheQueue.length = 0;
+    activeDownloads.clear();
   } catch (error) {
     logger.error(`[VideoCache] Error clearing cache:`, error);
     throw error;
@@ -191,10 +237,11 @@ export async function isCachedVideoValid(localPath: string): Promise<boolean> {
  * Preload a video into cache without waiting for download.
  * Useful for preloading next video in feed.
  * 
+ * @param videoId - ID of the video
  * @param remoteUrl - CDN URL of the video
  */
-export function preloadVideoAsync(remoteUrl: string): void {
-  cacheVideoLocally(remoteUrl).catch((err) => {
-    logger.warn(`[VideoCache] Preload failed for ${remoteUrl}:`, err);
+export function preloadVideoAsync(videoId: string, remoteUrl: string): void {
+  cacheVideoLocally(videoId, remoteUrl).catch((err) => {
+    logger.warn(`[VideoCache] Preload failed for video ${videoId} (${remoteUrl}):`, err);
   });
 }

--- a/frontend/utils/batteryOptimization.ts
+++ b/frontend/utils/batteryOptimization.ts
@@ -1,0 +1,23 @@
+import { Linking, Platform } from 'react-native';
+
+/**
+ * Directs the user to the system settings screen.
+ * On Android, opens the application details page so they can change battery optimization status.
+ * On iOS, opens the application settings page so they can enable "Always Allow" location settings.
+ */
+export async function openSystemSettingsForBackgroundTracking(): Promise<boolean> {
+  try {
+    const supported = await Linking.canOpenURL('app-settings:');
+    if (supported && Platform.OS === 'ios') {
+      await Linking.openURL('app-settings:');
+      return true;
+    }
+    
+    // Fallback/Android: open general application details/settings page
+    await Linking.openSettings();
+    return true;
+  } catch (err) {
+    console.warn('[BatteryOptimization] Failed to launch settings intent:', err);
+    return false;
+  }
+}

--- a/frontend/utils/kalmanFilter.ts
+++ b/frontend/utils/kalmanFilter.ts
@@ -1,0 +1,185 @@
+// frontend/utils/kalmanFilter.ts
+
+/**
+ * 2D Kalman Filter for GPS Telemetry Sanitization.
+ * 
+ * State Vector (X):
+ * [0] - latitude (degrees)
+ * [1] - longitude (degrees)
+ * [2] - velocity latitude (degrees/sec)
+ * [3] - velocity longitude (degrees/sec)
+ * 
+ * This filter dynamically computes Kalman Gain between prediction models
+ * and actual GPS coordinates, heavily weighing predictions when GPS accuracy
+ * is poor, and smoothing out instantaneous device coordinate jumps.
+ */
+export class KalmanFilter {
+  // State: [lat, lng, velLat, velLng]
+  private x: number[] = [0, 0, 0, 0];
+  
+  // State Covariance Matrix
+  private P: number[][] = [
+    [1, 0, 0, 0],
+    [0, 1, 0, 0],
+    [0, 0, 1, 0],
+    [0, 0, 0, 1]
+  ];
+
+  // Process noise variance (expected physical velocity deviation in meters/second)
+  private readonly Q_metres_per_sec = 0.08;
+  
+  // Last measurement timestamp in ms
+  private lastTimestamp: number = 0;
+
+  constructor(initialLat: number, initialLng: number, initialAccuracy: number, timestamp: number) {
+    this.x = [initialLat, initialLng, 0, 0];
+    const accVar = initialAccuracy * initialAccuracy;
+    this.P = [
+      [accVar, 0, 0, 0],
+      [0, accVar, 0, 0],
+      [0, 0, 1, 0],
+      [0, 0, 0, 1]
+    ];
+    this.lastTimestamp = timestamp;
+  }
+
+  /**
+   * Smooths incoming raw GPS coordinate updates.
+   * @param lat Raw latitude from GPS.
+   * @param lng Raw longitude from GPS.
+   * @param accuracy Raw accuracy radius in meters.
+   * @param timestamp Measurement timestamp in milliseconds.
+   * @returns Smoothed latitude and longitude coordinates.
+   */
+  public update(lat: number, lng: number, accuracy: number, timestamp: number): { latitude: number; longitude: number } {
+    if (this.lastTimestamp === 0) {
+      this.x = [lat, lng, 0, 0];
+      this.lastTimestamp = timestamp;
+      return { latitude: lat, longitude: lng };
+    }
+
+    const dt = (timestamp - this.lastTimestamp) / 1000.0;
+    if (dt <= 0) {
+      return { latitude: this.x[0], longitude: this.x[1] };
+    }
+    this.lastTimestamp = timestamp;
+
+    // --- 1. PREDICT PHASE ---
+    // State transition F: x_pred = x + vel * dt
+    const x_pred = [
+      this.x[0] + this.x[2] * dt,
+      this.x[1] + this.x[3] * dt,
+      this.x[2],
+      this.x[3]
+    ];
+
+    // Compute Pred Covariance P_pred = F*P*F^T + Q
+    const Q = this.getQ(dt);
+    const P_pred = [
+      [
+        this.P[0][0] + dt * (this.P[2][0] + this.P[0][2] + dt * this.P[2][2]) + Q[0][0],
+        this.P[0][1] + dt * (this.P[2][1] + this.P[0][3] + dt * this.P[2][3]) + Q[0][1],
+        this.P[0][2] + dt * this.P[2][2] + Q[0][2],
+        this.P[0][3] + dt * this.P[2][3] + Q[0][3]
+      ],
+      [
+        this.P[1][0] + dt * (this.P[3][0] + this.P[1][2] + dt * this.P[3][2]) + Q[1][0],
+        this.P[1][1] + dt * (this.P[3][1] + this.P[1][3] + dt * this.P[3][3]) + Q[1][1],
+        this.P[1][2] + dt * this.P[3][2] + Q[1][2],
+        this.P[1][3] + dt * this.P[3][3] + Q[1][3]
+      ],
+      [
+        this.P[2][0] + dt * this.P[2][2] + Q[2][0],
+        this.P[2][1] + dt * this.P[2][3] + Q[2][1],
+        this.P[2][2] + Q[2][2],
+        this.P[2][3] + Q[2][3]
+      ],
+      [
+        this.P[3][0] + dt * this.P[3][2] + Q[3][0],
+        this.P[3][1] + dt * this.P[3][3] + Q[3][1],
+        this.P[3][2] + Q[3][2],
+        this.P[3][3] + Q[3][3]
+      ]
+    ];
+
+    // --- 2. MEASUREMENT UPDATE PHASE ---
+    // Conversion: 1 degree latitude = 111320 meters
+    const METRES_PER_DEGREE = 111320.0;
+    const rVar = (accuracy / METRES_PER_DEGREE) * (accuracy / METRES_PER_DEGREE);
+
+    // Innovation covariance: S = H * P_pred * H^T + R
+    // H = [1 0 0 0; 0 1 0 0] mapping positions to measurement dimensions
+    const S = [
+      [P_pred[0][0] + rVar, P_pred[0][1]],
+      [P_pred[1][0], P_pred[1][1] + rVar]
+    ];
+
+    // Matrix Determinant for S
+    const det = S[0][0] * S[1][1] - S[0][1] * S[1][0];
+    if (det === 0) return { latitude: this.x[0], longitude: this.x[1] };
+    
+    // Invert S
+    const S_inv = [
+      [S[1][1] / det, -S[0][1] / det],
+      [-S[1][0] / det, S[0][0] / det]
+    ];
+
+    // Kalman Gain: K = P_pred * H^T * S_inv
+    const K = [
+      [P_pred[0][0] * S_inv[0][0] + P_pred[0][1] * S_inv[1][0], P_pred[0][0] * S_inv[0][1] + P_pred[0][1] * S_inv[1][1]],
+      [P_pred[1][0] * S_inv[0][0] + P_pred[1][1] * S_inv[1][0], P_pred[1][0] * S_inv[0][1] + P_pred[1][1] * S_inv[1][1]],
+      [P_pred[2][0] * S_inv[0][0] + P_pred[2][1] * S_inv[1][0], P_pred[2][0] * S_inv[0][1] + P_pred[2][1] * S_inv[1][1]],
+      [P_pred[3][0] * S_inv[0][0] + P_pred[3][1] * S_inv[1][0], P_pred[3][0] * S_inv[0][1] + P_pred[3][1] * S_inv[1][1]]
+    ];
+
+    // Compute innovation
+    const inn = [
+      lat - x_pred[0],
+      lng - x_pred[1]
+    ];
+
+    // State update: X = X_pred + K * Innovation
+    this.x = [
+      x_pred[0] + K[0][0] * inn[0] + K[0][1] * inn[1],
+      x_pred[1] + K[1][0] * inn[0] + K[1][1] * inn[1],
+      x_pred[2] + K[2][0] * inn[0] + K[2][1] * inn[1],
+      x_pred[3] + K[3][0] * inn[0] + K[3][1] * inn[1]
+    ];
+
+    // Covariance update: P = (I - KH) * P_pred
+    const KH = [
+      [K[0][0], K[0][1], 0, 0],
+      [K[1][0], K[1][1], 0, 0],
+      [K[2][0], K[2][1], 0, 0],
+      [K[3][0], K[3][1], 0, 0]
+    ];
+
+    for (let i = 0; i < 4; i++) {
+      for (let j = 0; j < 4; j++) {
+        let sum = 0;
+        for (let k = 0; k < 4; k++) {
+          sum += KH[i][k] * P_pred[k][j];
+        }
+        this.P[i][j] = P_pred[i][j] - sum;
+      }
+    }
+
+    return { latitude: this.x[0], longitude: this.x[1] };
+  }
+
+  // Generate Process Noise Covariance (Q) based on dt
+  private getQ(dt: number): number[][] {
+    const METRES_PER_DEGREE = 111320.0;
+    const qScale = (this.Q_metres_per_sec / METRES_PER_DEGREE) * (this.Q_metres_per_sec / METRES_PER_DEGREE);
+    const dt2 = dt * dt;
+    const dt3 = (dt2 * dt) / 2.0;
+    const dt4 = (dt2 * dt2) / 4.0;
+
+    return [
+      [dt4 * qScale, 0, dt3 * qScale, 0],
+      [0, dt4 * qScale, 0, dt3 * qScale],
+      [dt3 * qScale, 0, dt2 * qScale, 0],
+      [0, dt3 * qScale, 0, dt2 * qScale]
+    ];
+  }
+}


### PR DESCRIPTION
This PR fixes post vs. shorts navigation on the map screen (all-locations.tsx) and applies perfect circular styling to preview thumbnails on both the all-locations map and the TripScore country map.

### Additional Changes:
- **Shorts Video Alignment (shorts.tsx)**: Shifted the video container's top padding on the tabbed Shorts feed to Platform.OS === 'ios' ? 94 : 86 (a 70px increase) so that the bottom edge of the video rests directly on the progress bar and floating tab bar. Preserved default centering/padding on scoped profile views.